### PR TITLE
Add support for the default iCal colour property

### DIFF
--- a/convert_to_dhtmlx.py
+++ b/convert_to_dhtmlx.py
@@ -57,7 +57,7 @@ class ConvertToDhtmlx(ConversionStrategy):
             "url": calendar_event.get("URL"),
             "id": (uid, start_date),
             "type": "event",
-            "color": calendar_event.get("X-APPLE-CALENDAR-COLOR", "")
+            "color": calendar_event.get("COLOR", "") || calendar_event.get("X-APPLE-CALENDAR-COLOR", "")
         }
 
     def convert_error(self, error, url, tb_s):

--- a/convert_to_dhtmlx.py
+++ b/convert_to_dhtmlx.py
@@ -57,7 +57,7 @@ class ConvertToDhtmlx(ConversionStrategy):
             "url": calendar_event.get("URL"),
             "id": (uid, start_date),
             "type": "event",
-            "color": calendar_event.get("COLOR", "") || calendar_event.get("X-APPLE-CALENDAR-COLOR", "")
+            "color": calendar_event.get("COLOR", calendar_event.get("X-APPLE-CALENDAR-COLOR", ""))
         }
 
     def convert_error(self, error, url, tb_s):


### PR DESCRIPTION
Based on #52 and @drzraf's request on #88; also see [iCal documentation](https://icalendar.org/New-Properties-for-iCalendar-RFC-7986/5-9-color-property.html). As with #88, completely untested!!