### PR TITLE
fix shebang

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 from flask import Flask, render_template, make_response, request, jsonify, \
     redirect, send_from_directory
 from flask_caching import Cache


### PR DESCRIPTION
app failed to run when started from a virtualenv,
this was related to a change in Werkzeug.
reference: https://stackoverflow.com/questions/55271912/flask-cli-throws-oserror-errno-8-exec-format-error-when-run-through-docker