### PR TITLE
Use slash instead of path separator in template names

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,7 +165,7 @@ def get_calendar(type):
         template_name = specification["template"]
         all_template_names = os.listdir(CALENDAR_TEMPLATE_FOLDER)
         assert template_name in all_template_names, "Template names must be file names like \"{}\", not \"{}\".".format("\", \"".join(all_template_names), template_name)
-        template = os.path.join(CALENDARS_TEMPLATE_FOLDER_NAME, template_name)
+        template = CALENDARS_TEMPLATE_FOLDER_NAME + "/" + template_name
         return render_app_template(template, specification)
     raise ValueError("Cannot use extension {}. Please see the documentation or report an error.".format(type))
 


### PR DESCRIPTION
#86 