### PR TITLE
Add timezones

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ tox
 
 Changelog
 ---------
+- v1.7
+  - Add timezone functionality. See [Issue #171](https://github.com/niccokunzmann/open-web-calendar/issues/171).
 - v1.6
   - Add choice of Sunday or Monday for the start of the week [Issue 39](https://github.com/niccokunzmann/open-web-calendar/issues/39) - backed by [donation]!
 - v1.5

--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ import io
 import sys
 from convert_to_dhtmlx import ConvertToDhtmlx
 from convert_to_ics import ConvertToICS
+import pytz
 
 # configuration
 DEBUG = os.environ.get("APP_DEBUG", "true").lower() == "true"
@@ -72,7 +73,8 @@ def add_header(r):
 def get_configuration():
     """Return the configuration for the browser"""
     config = {
-        "default_specification": get_default_specification()
+        "default_specification": get_default_specification(), 
+        "timezones": pytz.all_timezones, # see https://stackoverflow.com/a/13867319
     }
     with open(DHTMLX_LANGUAGES_FILE, encoding="UTF-8") as file:
         config["dhtmlx"] = {
@@ -81,7 +83,7 @@ def get_configuration():
     return config
 
 def set_JS_headers(response):
-    repsonse = make_response(response)
+    response = make_response(response)
     response.headers['Access-Control-Allow-Origin'] = '*'
     # see https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMissingAllowHeaderFromPreflight
     response.headers['Access-Control-Allow-Headers'] = request.headers.get("Access-Control-Request-Headers")

--- a/default_specification.yml
+++ b/default_specification.yml
@@ -108,6 +108,10 @@ date: ""
 ## You can choose the start of the week. Either "mo" for Monday or "su" for Sunday.
 start_of_week: mo
 
+## You can fix the calendar to a specific time zone. Default is to take it from the browser.
+## Example values: "Europe/Berlin", "Asia/Shanghai" or "" for the timezone of the user/viewer.
+timezone: ""
+
 ###################### You will probably not change this. ######################
 ##
 ## The template is the file which shows the calendar.

--- a/static/index.html
+++ b/static/index.html
@@ -6,6 +6,7 @@
         <link href="css/index.css"
             rel="stylesheet" type="text/css" charset="utf-8">
         <script src="js/index.js"></script>
+        <script src="js/common.js"></script>
         <script src="configuration.js"></script>
     </head>
     <body>
@@ -164,6 +165,16 @@
                     <input type="checkbox" class="controls" value="today"   /><label for="today"   >Today</label>
                     <input type="checkbox" class="controls" value="date"    /><label for="date"    >Date</label>
                   </form>
+                </p>
+                <h3 id="tabs">Time Zone</h3>
+                <p>
+                  The timezone is taken from the browser of the user.
+                  If you want your calendar to be fixed in one timezone,
+                  you have the option below. Your browser uses the time zone
+                  <span id="timezone-info">loading...</span>.
+                  <select id="select-timezone">
+                      <option value="">use the timezone of the browser</option>
+                  </select>
                 </p>
                 <h3 id="specification">Hosting the Specification</h3>
                 <p>

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,0 +1,9 @@
+/*
+ * Common functions.
+ */
+
+
+function getTimezone() {
+    // see https://stackoverflow.com/a/37512371
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}

--- a/static/js/configure.js
+++ b/static/js/configure.js
@@ -145,7 +145,8 @@ function loadCalendar() {
     // set format of dates in the data source
     scheduler.config.xml_date="%Y-%m-%d %H:%i";
     // use UTC, see https://docs.dhtmlx.com/scheduler/api__scheduler_server_utc_config.html
-    scheduler.config.server_utc = true;
+    // scheduler.config.server_utc = true; // we use timezones now
+    
     scheduler.config.readonly = true;
     // set the start of the week. See https://docs.dhtmlx.com/scheduler/api__scheduler_start_on_monday_config.html
     scheduler.config.start_on_monday = specification["start_of_week"] == "mo";
@@ -197,6 +198,10 @@ function loadCalendar() {
 
     schedulerUrl = document.location.pathname.replace(/.html$/, ".events.json") +
         document.location.search;
+    // add the time zone if not specified
+    if (specification.timezone == "") {
+        schedulerUrl += "&timezone=" + getTimezone();
+    }
         
     scheduler.attachEvent("onLoadError", function(xhr) {
         disableLoader();

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -121,6 +121,8 @@ function getSpecification() {
     setSpecificationValueFromId(specification, "skin", "select-skin");
     /* Start of the week */
     setSpecificationValueFromId(specification, "start_of_week", "select-start-of-week");
+    /* timezone */
+    setSpecificationValueFromId(specification, "timezone", "select-timezone");
     /* color and CSS */
     var css = configuration.default_specification.css;
     var colorInputs = document.getElementsByClassName("color-input");
@@ -285,7 +287,6 @@ function fillDefaultSpecificationLink() {
 
 
 function fillLanguageChoice() {
-    // see
     var select = document.getElementById("select-language");
     var selected = false;
     configuration.dhtmlx.languages.forEach(function (language){
@@ -305,6 +306,25 @@ function fillLanguageChoice() {
     // see https://stackoverflow.com/a/7858323/1320237
     select.onchange = updateOutputs;
 }
+
+function fillTimezoneChoice() {
+    // inform the user
+    var timezone = getTimezone();
+    var timezoneInfo = document.getElementById("timezone-info");
+    timezoneInfo.innerText = timezone;
+    var select = document.getElementById("select-timezone");
+    var option = document.createElement("option");
+    option.text = option.value = timezone;
+    select.appendChild(option);
+    configuration.timezones.forEach(function (timezone){
+        var option = document.createElement("option");
+        option.text = option.value = timezone;
+        select.appendChild(option);
+    });
+    select.value = configuration.default_specification.timezone;
+    changeSpecificationOnChange(select);
+}
+
 
 function initializeSkinChoice() {
     var select = document.getElementById("select-skin");
@@ -389,6 +409,7 @@ window.addEventListener("load", function(){
     // initialization
     listenForCSSChanges();
     fillLanguageChoice();
+    fillTimezoneChoice();
     initializeStartOfWeek();
     initializeSkinChoice();
     initializeTitle();

--- a/templates/calendars/dhtmlx.html
+++ b/templates/calendars/dhtmlx.html
@@ -12,6 +12,8 @@
             charset="utf-8"></script>
         <script src="js/configure.js"
             charset="utf-8"></script>
+        <script src="js/common.js"
+            charset="utf-8"></script>
         <link href="css/dhtmlx/{{ specification['skin'] | safe }}"
             rel="stylesheet" type="text/css" charset="utf-8">
         <link href="css/dhtmlx/style.css"

--- a/test/test_date_to_string.py
+++ b/test/test_date_to_string.py
@@ -6,26 +6,30 @@ from pytz import timezone, utc
 berlin = timezone("Europe/Berlin")
 eastern = timezone('US/Eastern')
 
-@pytest.mark.parametrize("date,timeshift_minutes,expected", [
+UTC = "UTC"
+BERLIN = "Europe/Berlin"
+EASTERN = "US/Eastern"
+
+@pytest.mark.parametrize("date,tz,expected", [
     # test date object without time zone
-    (datetime.date(2019, 3, 23),    0, "2019-03-23 00:00"),
-    (datetime.date(2019, 3, 23), -120, "2019-03-22 22:00"),
-    (datetime.date(2019, 3, 23),  120, "2019-03-23 02:00"),
+    (datetime.date(2019, 3, 23), UTC, "2019-03-23 00:00"),
+    (datetime.date(2019, 3, 23), BERLIN, "2019-03-23 00:00"),
+    (datetime.date(2019, 3, 23), EASTERN, "2019-03-23 00:00"),
     # test datetime object without time zone
-    (datetime.datetime(2019,  6,  2, 20),           0, "2019-06-02 20:00"),
-    (datetime.datetime(2019,  4, 20, 10, 10),    -120, "2019-04-20 08:10"),
-    (datetime.datetime(2019, 12,  1,  0, 13, 23), 120, "2019-12-01 02:13"),
+    (datetime.datetime(2019,  6,  2, 20), UTC, "2019-06-02 20:00"),
+    (datetime.datetime(2019,  4, 20, 10, 10), BERLIN, "2019-04-20 10:10"),
+    (datetime.datetime(2019, 12,  1,  0, 13, 23), EASTERN, "2019-12-01 00:13"),
     # test datetime object with time zone
-    (berlin.localize(datetime.datetime(2019,  6,  2, 20)),           0, "2019-06-02 18:00"),
-    (berlin.localize(datetime.datetime(2019,  4, 20, 10, 10)),    -120, "2019-04-20 08:10"),
-    (berlin.localize(datetime.datetime(2019, 12,  1,  0, 13, 23)), 120, "2019-11-30 23:13"),
-    (utc.localize(datetime.datetime(2019,  6,  2, 20)),           0, "2019-06-02 20:00"),
-    (utc.localize(datetime.datetime(2019,  4, 20, 10, 10)),    -120, "2019-04-20 10:10"),
-    (utc.localize(datetime.datetime(2019, 12,  1,  0, 13, 23)), 120, "2019-12-01 00:13"),
+    (berlin.localize(datetime.datetime(2019,  6,  2, 20)), UTC, "2019-06-02 18:00"),
+    (berlin.localize(datetime.datetime(2019,  4, 20, 10, 10)), BERLIN, "2019-04-20 10:10"),
+    (berlin.localize(datetime.datetime(2019, 12,  1,  0, 13, 23)), EASTERN, "2019-11-30 18:13"),
+    (utc.localize(datetime.datetime(2019,  6,  2, 20)), UTC, "2019-06-02 20:00"),
+    (utc.localize(datetime.datetime(2019,  4, 20, 10, 10)), BERLIN, "2019-04-20 12:10"),
+    (utc.localize(datetime.datetime(2019, 12,  1,  0, 13, 23)), EASTERN, "2019-11-30 19:13"),
 ])
-def test_date_to_string_conversion(date, timeshift_minutes, expected):
+def test_date_to_string_conversion(date, tz, expected):
     """Convert dates and datetime objects for the events.json"""
-    string = ConvertToDhtmlx({"timeshift":timeshift_minutes}).date_to_string(date)
+    string = ConvertToDhtmlx({"timezone":tz}).date_to_string(date)
     print(date)
     assert string == expected
 


### PR DESCRIPTION
This fixes #171.

This replaces the DHTMLX scheduler timeshift with the timezone from the browser.

Contributes to:
- https://github.com/niccokunzmann/open-web-calendar/issues/154
- #12

Tests are welcome!