### PR TITLE
Broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ You can deploy the app using Heroku.
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
-Heroku uses [gunicorn](http://flask.pocoo.org/docs/dev/deploying/wsgi-standalone/#gunicorn)
+Heroku uses [gunicorn](https://gunicorn.org/)
 to run the server, see the [Procfile](Procfile).
 
 Research

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Research
   - https://sourceforge.net/projects/phpicalendar/
 - https://icalendar.readthedocs.io/
 - https://github.com/rianjs/ical.net
-- https://stackoverflow.com/questions/4671764/is-there-a-javascript-calendar-that-takes-an-ical-link-as-input-to-display-event
+- https://web.archive.org/web/20210201222328/https://stackoverflow.com/questions/4671764/is-there-a-javascript-calendar-that-takes-an-ical-link-as-input-to-display-event
 - https://www.webgui.org/content-managers-guide-wiki/calendar
 - https://www.quora.com/What-calendars-can-I-embed-in-my-website-that-arent-Google-Calendar
 

--- a/app.py
+++ b/app.py
@@ -135,7 +135,7 @@ def get_specification(query=None):
         specification.update(url_specification_values)
     for parameter in query:
         # get a list of arguments
-        # see http://werkzeug.pocoo.org/docs/0.14/datastructures/#werkzeug.datastructures.MultiDict
+        # see https://web.archive.org/web/20230325034825/https://werkzeug.palletsprojects.com/en/0.14.x/datastructures/
         value = query.getlist(parameter, None)
         if len(value) == 1:
             value = value[0]

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,6 +1,6 @@
 """Browser fixture setup and teardown
 
-see https://behave.readthedocs.io/en/latest/practical_tips.html#selenium-example
+see https://behave.readthedocs.io/en/stable/practical_tips.html
 """
 import  sys
 import os

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,6 +1,6 @@
 """Browser fixture setup and teardown
 
-see https://behave.readthedocs.io/en/stable/practical_tips.html
+see https://behave.readthedocs.io/en/stable/practical_tips.html#selenium-example
 """
 import  sys
 import os


### PR DESCRIPTION
There are multiple broken links in this project. Here are the ones I have fixed:

http://flask.pocoo.org/docs/dev/deploying/wsgi-standalone/#gunicorn --> https://gunicorn.org/

https://stackoverflow.com/questions/4671764/is-there-a-javascript-calendar-that-takes-an-ical-link-as-input-to-display-event --> https://web.archive.org/web/20210201222328/https://stackoverflow.com/questions/4671764/is-there-a-javascript-calendar-that-takes-an-ical-link-as-input-to-display-event

http://werkzeug.pocoo.org/docs/0.14/datastructures/#werkzeug.datastructures.MultiDict --> https://web.archive.org/web/20230325034825/https://werkzeug.palletsprojects.com/en/0.14.x/datastructures/

https://behave.readthedocs.io/en/latest/practical_tips.html#selenium-example -->
https://behave.readthedocs.io/en/stable/practical_tips.html#selenium-example

These broken links where found with [link-inspector](https://github.com/justindhillon/link-inspector). If you find this pr useful, give the project a star ⭐

Signed off: [justin.singh.dhillon@gmail.com](mailto:justin.singh.dhillon@gmail.com)