### PR TITLE
use text/javascript

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,7 @@ from convert_to_dhtmlx import ConvertToDhtmlx
 from convert_to_ics import ConvertToICS
 import pytz
 import translate
+import mimetypes
 
 # configuration
 DEBUG = os.environ.get("APP_DEBUG", "true").lower() == "true"
@@ -107,7 +108,7 @@ def make_js_file_response(content:str) -> Response:
     """Modify the response to set the content type for .js files."""
     response = make_response(content)
     set_JS_headers(response)
-    response.headers['Content-Type'] = "application/javascript"
+    response.headers['Content-Type'] = "text/javascript"
     return response
 
 

--- a/test/test_issue_241_mime_type_for_js.py
+++ b/test/test_issue_241_mime_type_for_js.py
@@ -2,7 +2,7 @@
 
 See https://github.com/niccokunzmann/open-web-calendar/issues/241
 
-We expect application/javascript.
+We expect text/javascript.
 https://stackoverflow.com/a/189877/1320237
 """
 import pytest
@@ -21,6 +21,4 @@ def test_mime_type_of_configuration_js(client, js_url):
     """Check the Content-Type header.
     """
     response = client.get(js_url)
-    assert \
-        "application/javascript" in response.content_type or \
-        "text/javascript" in response.content_type
+    assert "text/javascript" in response.content_type.split(";")


### PR DESCRIPTION
application/javascript is deprecated again.
https://www.rfc-editor.org/rfc/rfc9239.html#name-common-javascript-media-typ