### PR TITLE
Use timeshift when timezone name is not proper

### DIFF
--- a/convert_to_dhtmlx.py
+++ b/convert_to_dhtmlx.py
@@ -14,13 +14,17 @@ def is_date(date):
 
 class ConvertToDhtmlx(ConversionStrategy):
     """Convert events to dhtmlx. This conforms to a stratey pattern.
-    
+
     - timeshift_minutes is the timeshift specified by the calendar
         for dates.
     """
-    
+
     def created(self):
-        self.timezone = pytz.timezone(self.specification["timezone"])
+        """Set attribtues when created."""
+        try:
+            self.timezone = pytz.timezone(self.specification["timezone"])
+        except pytz.UnknownTimeZoneError:
+            self.timezone = pytz.FixedOffset(-int(self.specification["timeshift"]))
 
     def date_to_string(self, date):
         """Convert a date to a string."""
@@ -98,10 +102,10 @@ class ConvertToDhtmlx(ConversionStrategy):
             "id": id(error),
             "type": "error"
         }
-    
+
     def merge(self):
         return jsonify(self.components)
-        
+
     def collect_components_from(self, calendars):
         # see https://stackoverflow.com/a/16115575/1320237
         today = (
@@ -125,6 +129,3 @@ class ConvertToDhtmlx(ConversionStrategy):
                 for event in events:
                     json_event = self.convert_ical_event(event)
                     self.components.append(json_event)
-                
-
-

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,9 +4,15 @@ import pytest
 from unittest.mock import Mock
 import requests
 
-HERE = os.path.dirname(__name__) or "."
+# constants
+HERE = os.path.dirname(__file__) or "."
+CALENDAR_DIRECTORY = os.path.join(HERE, "..", "features", "calendars")
+
+# relative imports
 sys.path.append(os.path.join(os.path.abspath(HERE), ".."))
 sys.path.append(os.path.abspath(HERE))
+from app import cache_url
+
 
 @pytest.fixture(autouse=True)
 def no_requests(monkeypatch):
@@ -51,3 +57,19 @@ def client(app):
 @pytest.fixture()
 def runner(app):
     return app.test_cli_runner()
+
+
+@pytest.fixture()
+def calendar_urls():
+    """Mapping the calendar name without .ics to the cached url.
+
+    The files are located in the CALENDAR_FOLDER.
+    """
+    mapping = {}
+    for file in os.listdir(CALENDAR_DIRECTORY):
+        if file.lower().endswith(".ics"):
+            url = "http://test.examples.local/" + file
+            with open(os.path.join(CALENDAR_DIRECTORY, file)) as f:
+                cache_url(url, f.read())
+            mapping[file[:-4]] = url
+    return mapping

--- a/test/test_special_timezones.py
+++ b/test/test_special_timezones.py
@@ -1,0 +1,31 @@
+"""Test that special time zones are also handeled correctly.
+
+See https://github.com/niccokunzmann/open-web-calendar/issues/190
+"""
+import pytest
+
+
+@pytest.mark.parametrize(
+    "timezone,event_start,timeshift",
+    [
+        ("", "2019-03-04 07:00", 0),  # UTC
+        ("", "2019-03-04 04:00", 180),  # UTC-3
+        ('Etc/GMT 3', "2019-03-04 04:00", 180),
+        ('Etc/GMT 5', "2019-03-04 02:00", 300),
+        ('undefined', "2019-03-04 06:00", 60),
+        ('undefined', "2019-03-04 07:00", 0),
+        ('UTC', "2019-03-04 07:00", 180), # timeshift ignored, proper timezone
+        ('Europe/London', "2019-03-04 07:00", -240), # timeshift ignored, proper timezone
+        ('Europe/Berlin', "2019-03-04 08:00", 0), # timeshift ignored, proper timezone
+    ]
+)
+def test_that_timezones_do_not_create_an_error(timezone, client, event_start, calendar_urls, timeshift):
+    """These time zones are a bit special, not 1:1 Python.
+
+    This is why we use the timeshift given.
+    """
+    response = client.get(f"/calendar.events.json?url={calendar_urls['one-event']}&timezone={timezone}&timeshift={timeshift}&from=2019-03-04&to=2019-03-05")
+    assert response.status_code == 200
+    assert len(response.json) == 1
+    event = response.json[0]
+    assert event["start_date"] == event_start, f"Timezone differs in offset: {timezone}"


### PR DESCRIPTION
This fixes https://github.com/niccokunzmann/open-web-calendar/issues/190

The unknown timezone names are avoided and the timeshift is used.