### PR TITLE
Expose the hour_format parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ Changelog
 [changelog]: #changelog
 
 - v1.26 (unreleased)
-  - Add a red bar at the current time in the week view and the day view.
+  - Add a red bar at the current time in the week view and the day view, see [PR 265](https://github.com/niccokunzmann/open-web-calendar/pull/265).
+  - Expose the `hour_format` parameter and add choices for the 12h format, see [PR 266](https://github.com/niccokunzmann/open-web-calendar/pull/266).
 - v1.25
   - Update dependencies
   - Implement work week view, see [Issue 258](https://github.com/niccokunzmann/open-web-calendar/issues/258)

--- a/default_specification.yml
+++ b/default_specification.yml
@@ -134,6 +134,13 @@ start_of_week: mo
 ## Example values: "Europe/Berlin", "Asia/Shanghai" or "" for the timezone of the user/viewer.
 timezone: ""
 
+## You can change the format of how a time is displayed.
+## See also https://docs.dhtmlx.com/scheduler/settings_format.html
+hour_format: "%H:%i"     # examples: 01:30, 13:45
+#hour_format: "%G:%i"    # examples:  1:30, 13:45
+#hour_format: "%g:%i %a" # examples:  1:30 am, 1:45 pm
+
+
 ###################### Change this if you modify the project. ######################
 ##
 ## Where the current modifications can be obtained.

--- a/features/issue-207-change-hour-format.feature
+++ b/features/issue-207-change-hour-format.feature
@@ -1,0 +1,46 @@
+Feature: The clock convention can be changed from the 24 hour format to the 12 hour format.
+
+    Scenario Outline: I view the calendar in the 24h format - this is the default.
+      Given we add the calendar "one-event"
+        And we set the "tab" parameter to "<tab>"
+       When we look at 2024-01-18
+       Then we can see the text "00:00"
+        And we can see the text "12:00"
+        And we can see the text "23:00"
+        And we cannot see the text "pm"
+        And we cannot see the text "PM"
+
+     Examples:
+       | tab  |
+       | day  |
+       | week |
+
+    Scenario Outline: I view the calendar in the 24h format with no 0 at the start.
+      Given we add the calendar "one-event"
+        And we set the "tab" parameter to "<tab>"
+        And we set the "hour_format" parameter to "%G:%i"
+       When we look at 2024-01-18
+       Then we can see the text "0:00"
+        And we can see the text "12:00"
+        And we can see the text "23:00"
+        And we cannot see the text "00:00"
+
+     Examples:
+       | tab  |
+       | day  |
+       | week |
+
+    Scenario Outline: I view the calendar in the 12h format.
+      Given we add the calendar "one-event"
+        And we set the "tab" parameter to "<tab>"
+        And we set the "hour_format" parameter to "%g:%i %a"
+       When we look at 2024-01-18
+       Then we can see the text "12:00 am"
+        And we can see the text "12:00 pm"
+        And we can see the text "11:00 pm"
+        And we cannot see the text "13:00"
+
+     Examples:
+       | tab  |
+       | day  |
+       | week |

--- a/static/js/configure.js
+++ b/static/js/configure.js
@@ -132,7 +132,12 @@ function setLoader() {
 }
 
 function loadCalendar() {
-    var format = scheduler.date.date_to_str("%H:%i");
+    /* Format the time of the hour.
+     * see https://docs.dhtmlx.com/scheduler/settings_format.html
+     * see https://docs.dhtmlx.com/scheduler/api__scheduler_hour_date_config.html
+     */
+    scheduler.config.hour_date = specification["hour_format"];
+    var format = scheduler.date.date_to_str(scheduler.config.hour_date);
     setLocale(scheduler);
     // load plugins, see https://docs.dhtmlx.com/scheduler/migration_from_older_version.html#5360
     scheduler.plugins({

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -116,6 +116,8 @@ function getSpecification() {
         }
     }
 
+    /* hour format */
+    setSpecificationValueFromId(specification, "hour_format", "select-hour-format");
     /* language */
     setSpecificationValueFromId(specification, "language", "select-language");
     /* skin */
@@ -320,7 +322,7 @@ function initializeStartDate() {
 
 function initializeFirstHour() {
     var input = document.getElementById("starting-hour");
-    input.value = configuration.default_specification.starting_hour; 
+    input.value = configuration.default_specification.starting_hour;
     changeSpecificationOnChange(input);
 }
 
@@ -339,6 +341,12 @@ function initializeTimeIncrement() {
     for (let c of input.getElementsByClassName("time-increment-input")) {
         changeSpecificationOnChange(c);
     }
+}
+
+function initializeHourFormat() {
+    var input = document.getElementById("select-hour-format");
+    input.value = configuration.default_specification.hour_format;
+    changeSpecificationOnChange(input);
 }
 
 function initializeStartOfWeek() {
@@ -420,6 +428,7 @@ window.addEventListener("load", function(){
     initializeFirstHour();
     initializeLastHour();
     initializeTimeIncrement();
+    initializeHourFormat();
     initializeLoader();
     initializeLinkTargetChoice();
     updateCalendarInputs();
@@ -462,4 +471,3 @@ function arraysEqual(a, b) {
   }
   return true;
 }
-

--- a/templates/index.html
+++ b/templates/index.html
@@ -84,6 +84,18 @@
                         <input class="time-increment-input" type="radio" id="time-1" name="time-select" value="1" /><label for="time-60">{{ html("time-increment-60") }}</label>
                     </form>
                 </p>
+                <h3>{{ html("hour-format-title") }}</h3>
+                <p>
+                    {{ html("hour-format-description") }} <a href="https://docs.dhtmlx.com/scheduler/settings_format.html">{{ html("hour-format-specification-link") }}</a><br/>
+                    <select id="select-hour-format">
+                        <option value="%G:%i">24:00 - 1:15, 13:45</option>
+                        <option value="%H:%i">24:00 - 01:15, 13:45</option>
+                        <option value="%g:%i %a">am/pm - 1:15 am, 1:45 pm</option>
+                        <option value="%h:%i %a">am/pm - 01:15 am, 1:45 pm</option>
+                        <option value="%g:%i %A">AM/PM - 1:15 AM, 1:45 PM</option>
+                        <option value="%h:%i %A">AM/PM - 01:15 AM, 1:45 PM</option>
+                    </select>
+                </p>
                 <h3>{{ html("language-title") }}</h3>
                 <p>
                     {{ html("language-description") }}<br/>
@@ -114,9 +126,9 @@
                 </p>
                 <h3>{{ html("configure-week-title") }}</h3>
                 <p>
-                    {{ html("configure-week-description") }}<br/>
                     <select id="select-start-of-week">
                         <option value="mo">{{ html("calendar.date_day_full_mon") }} - {{ html("calendar.date_day_full_sun") }}</option>
+                        {{ html("configure-week-description") }}<br/>
                         <option value="su">{{ html("calendar.date_day_full_sun") }} - {{ html("calendar.date_day_full_mon") }}</option>
                         <option value="work">{{ html("calendar.date_day_full_mon") }} - {{ html("calendar.date_day_full_fri") }}</option>
                     </select>

--- a/translations/en/index.yml
+++ b/translations/en/index.yml
@@ -76,6 +76,16 @@ time-increment-30: "30 minutes"
 time-increment-60: "1 hour"
 
 
+# Heading of option
+# https://open-web-calendar.hosted.quelltext.eu/#translate-hour-format-title
+hour-format-title: "Clock Convention"
+# Description of option
+# https://open-web-calendar.hosted.quelltext.eu/#translate-hour-format-description
+hour-format-description: "You can choose between the 24 hour clock and the 12 hour clock. More options are possible."
+# Link to the specification
+# https://open-web-calendar.hosted.quelltext.eu/#translate-hour-format-description
+hour-format-specification-link: "View the specification."
+
 
 # Heading of option
 # https://open-web-calendar.hosted.quelltext.eu/#translate-language-title


### PR DESCRIPTION
This exposes the hour_format as a parameter to directly set the dhtmlx scheduler config.

This fixes #207 and contributes to #220. 

![image](https://github.com/niccokunzmann/open-web-calendar/assets/564768/e5d4b793-1cd6-44ac-8414-428562e21bea)

![image](https://github.com/niccokunzmann/open-web-calendar/assets/564768/09cf24e4-7e3b-4aa4-9055-8b05f3f4ab77)

