### PR TITLE
Responsive

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
           tox_env: "web -- -D browser=chrome"
         # run Firefox in iPhone 11 responsive layout
         - python: "3.9"
-          tox_env: "web -D window=375x812"
+          tox_env: "web -- -D window=375x812"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,10 +15,15 @@ jobs:
         tox_env: ["py"]
         # see https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
+        # run Firefox
         - python: "3.9"
           tox_env: web
+        # run Chrome
         - python: "3.9"
           tox_env: "web -- -D browser=chrome"
+        # run Firefox in iPhone 11 responsive layout
+        - python: "3.9"
+          tox_env: "web -D window=375x812"
 
     steps:
       - uses: actions/checkout@v3

--- a/behave.ini
+++ b/behave.ini
@@ -1,4 +1,7 @@
-# see https://stackoverflow.com/a/58049063/1320237
-# see https://behave.readthedocs.io/en/latest/new_and_noteworthy_v1.2.5/?highlight=userdata#index-7
+## see https://stackoverflow.com/a/58049063/1320237
+## see https://behave.readthedocs.io/en/latest/new_and_noteworthy_v1.2.5/?highlight=userdata#index-7
 [behave.userdata]
+## use one of the specified browsers in environment.py
 browser = firefox
+## set the width and height of the browser, i.e. 375x812 for iPhone 11
+#window = 375x812

--- a/default_specification.yml
+++ b/default_specification.yml
@@ -140,6 +140,9 @@ hour_format: "%H:%i"     # examples: 01:30, 13:45
 #hour_format: "%G:%i"    # examples:  1:30, 13:45
 #hour_format: "%g:%i %a" # examples:  1:30 am, 1:45 pm
 
+## This is the width in pixels at which the calendar switches to a compact
+## layout in order to fit in all the elements.
+compact_layout_width: 600
 
 ###################### Change this if you modify the project. ######################
 ##

--- a/features/environment.py
+++ b/features/environment.py
@@ -83,6 +83,16 @@ browsers = {
     "safari": browser_safari,
 }
 
+
+@fixture
+def set_window_size(context):
+    """Set the window size of the browser."""
+    # see https://stackoverflow.com/a/55878622/1320237
+    if "window" in context.config.userdata:
+        width, height = context.config.userdata["window"].split("x")
+        context.browser.set_window_size(int(width), int(height))
+
+
 def serve_calendar_files(host, port, directory=os.path.join(HERE, "calendars")):
     """Serve the calendar files so they can be requested.
 
@@ -136,6 +146,7 @@ def calendars_server(context):
 def before_all(context):
     browser = browsers[context.config.userdata["browser"]]
     use_fixture(browser, context)
+    use_fixture(set_window_size, context)
     use_fixture(app_server, context)
     use_fixture(calendars_server, context)
 

--- a/features/select-tabs-and-control-buttons.feature
+++ b/features/select-tabs-and-control-buttons.feature
@@ -1,0 +1,49 @@
+Feature: I would like to choose which tabs to display.
+
+  Scenario: I see the default tabs.
+    Given we add the calendar "one-event"
+     When we look at 2024-01-18
+     Then we can see the text "DAY"
+     Then we can see the text "WEEK"
+     Then we can see the text "MONTH"
+     Then we can see the text "January 2024"
+     Then we cannot see the text "AGENDA"
+
+  Scenario: I see all possible tabs.
+    Given we add the calendar "one-event"
+      And we set the "tabs" parameter to ["month","week","day","agenda"]
+     When we look at 2024-01-18
+     Then we can see the text "DAY"
+     Then we can see the text "WEEK"
+     Then we can see the text "MONTH"
+     Then we can see the text "AGENDA"
+
+  Scenario: I do not allow any controls.
+    Given we add the calendar "one-event"
+      And we set the "controls" parameter to ""
+     When we look at 2024-01-18
+     Then we cannot see a dhx_cal_prev_button
+     Then we cannot see a dhx_cal_today_button
+     Then we cannot see a dhx_cal_next_button
+
+  Scenario: I can use the default controls.
+    Given we add the calendar "one-event"
+     When we look at 2024-01-18
+     Then we can see a dhx_cal_prev_button
+     Then we can see a dhx_cal_today_button
+     Then we can see a dhx_cal_next_button
+
+  Scenario: I do not see any tabs.
+    Given we add the calendar "one-event"
+      And we set the "tabs" parameter to ""
+     When we look at 2024-01-18
+#     Then we cannot see the text "DAY"  # included in TODAY
+     Then we cannot see the text "WEEK"
+     Then we cannot see the text "MONTH"
+     Then we cannot see the text "AGENDA"
+
+  Scenario: I can disable the TODAY button but still see the DAY button.
+    Given we add the calendar "one-event"
+      And we set the "controls" parameter to ""
+     When we look at 2024-01-18
+     Then we can see the text "DAY"

--- a/features/steps/browser_steps.py
+++ b/features/steps/browser_steps.py
@@ -27,9 +27,9 @@ def step_impl(context, calendar_name):
     context.specification["url"].append(calendar_url)
 
 
-@given('we set the "{parameter_name}" parameter to "{parameter_value}"')
+@given('we set the "{parameter_name}" parameter to {parameter_value}')
 def step_impl(context, parameter_name, parameter_value):
-    context.specification[parameter_name] = parameter_value
+    context.specification[parameter_name] = json.loads(parameter_value)
 
 
 @when(u'we look at {date}')
@@ -87,12 +87,23 @@ def get_body_text(context):
 
 @then(u'we cannot see the text "{text}"')
 def step_impl(context, text):
-    assert text not in get_body_text(context)
+    assert text not in get_body_text(context), f"{repr(text)} is visible but should not be visible"
 
 
 @then(u'we can see the text "{text}"')
 def step_impl(context, text):
-    assert text in get_body_text(context)
+    assert text in get_body_text(context), f"{repr(text)} is invisible but should be visible"
+
+
+@then(u'we can see a {cls}')
+def step_impl(context, cls):
+    assert context.browser.find_elements(By.CLASS_NAME, cls), f"Expected to find elements of class {cls}"
+
+
+@then(u'we cannot see a {cls}')
+def step_impl(context, cls):
+    assert not context.browser.find_elements(By.CLASS_NAME, cls), f"Expected to not find elements of class {cls}"
+
 
 @when(u"we open the about page")
 def step_impl(context):

--- a/static/js/configure.js
+++ b/static/js/configure.js
@@ -131,6 +131,12 @@ function setLoader() {
     }
 }
 
+/* Disable/Enable features based on touch/mouse-over gestures
+ * see https://stackoverflow.com/a/52855084/1320237
+ */
+var IS_TOUCH_SCREEN = window.matchMedia("(pointer: coarse)").matches;
+var HAS_TOOLTIP = !IS_TOUCH_SCREEN;
+
 function loadCalendar() {
     /* Format the time of the hour.
      * see https://docs.dhtmlx.com/scheduler/settings_format.html
@@ -145,7 +151,7 @@ function loadCalendar() {
         multisource: true,
         quick_info: true,
         recurring: false,
-        tooltip: true,
+        tooltip: HAS_TOOLTIP,
         readonly: true,
         limit: true,
     });
@@ -153,6 +159,9 @@ function loadCalendar() {
     scheduler.config.xml_date="%Y-%m-%d %H:%i";
     // use UTC, see https://docs.dhtmlx.com/scheduler/api__scheduler_server_utc_config.html
     // scheduler.config.server_utc = true; // we use timezones now
+
+    // responsive lightbox, see https://docs.dhtmlx.com/scheduler/touch_support.html
+    scheduler.config.responsive_lightbox = true;
 
     scheduler.config.readonly = true;
     /* Add a red line at the current time.
@@ -182,13 +191,15 @@ function loadCalendar() {
     scheduler.templates.event_bar_text = function(start, end, event){
         return event.text;
     }
-    // tool tip
+    // tooltip
     // see https://docs.dhtmlx.com/scheduler/tooltips.html
-    scheduler.templates.tooltip_text = function(start, end, event) {
-        return template.summary(event) + template.details(event) + template.location(event);
-    };
-    scheduler.tooltip.config.delta_x = 1;
-    scheduler.tooltip.config.delta_y = 1;
+    if (HAS_TOOLTIP) {
+        scheduler.templates.tooltip_text = function(start, end, event) {
+            return template.summary(event) + template.details(event) + template.location(event);
+        };
+        scheduler.tooltip.config.delta_x = 1;
+        scheduler.tooltip.config.delta_y = 1;
+    }
     // quick info
     scheduler.templates.quick_info_title = function(start, end, event){
         return template.summary(event);

--- a/static/js/configure.js
+++ b/static/js/configure.js
@@ -131,6 +131,67 @@ function setLoader() {
     }
 }
 
+function getHeader() {
+    // elements that do not occur in the list will always be permitted
+    var useHeaderElement = {
+      "prev": specification.controls.includes("previous") ,
+      "date": specification.controls.includes("date"),
+      "next": specification.controls.includes("next"),
+      "day": specification.tabs.includes("day"),
+      "week": specification.tabs.includes("week"),
+      "month": specification.tabs.includes("month"),
+      "today": specification.controls.includes("today"),
+      "agenda": specification.tabs.includes("agenda"),
+    }
+    function showSelected(headerElements) {
+      return headerElements.filter(function(element){
+        return useHeaderElement[element] != false; // null for absent
+      });
+    }
+    // switch the header to a compact one
+    // see https://docs.dhtmlx.com/scheduler/touch_support.html
+    if (window.innerWidth < Number.parseInt(specification.compact_layout_width)) {
+        return {
+            rows: [
+                {
+                    cols: showSelected([
+                        "prev",
+                        "date",
+                        "next",
+                    ])
+                },
+                {
+                    cols: showSelected([
+                        "day",
+                        "week",
+                        "month",
+                        "agenda",
+                        "spacer",
+                        "today"
+                    ])
+                }
+            ]
+          };
+    } else {
+        return showSelected([
+            "day",
+            "week",
+            "month",
+            "agenda",
+            "date",
+            "prev",
+            "today",
+            "next"
+        ]);
+    }
+}
+
+function resetConfig() {
+    scheduler.config.header = getHeader();
+    return true;
+}
+
+
 /* Disable/Enable features based on touch/mouse-over gestures
  * see https://stackoverflow.com/a/52855084/1320237
  */
@@ -157,12 +218,14 @@ function loadCalendar() {
     });
     // set format of dates in the data source
     scheduler.config.xml_date="%Y-%m-%d %H:%i";
-    // use UTC, see https://docs.dhtmlx.com/scheduler/api__scheduler_server_utc_config.html
-    // scheduler.config.server_utc = true; // we use timezones now
 
     // responsive lightbox, see https://docs.dhtmlx.com/scheduler/touch_support.html
     scheduler.config.responsive_lightbox = true;
+    resetConfig();
+    scheduler.attachEvent("onBeforeViewChange", resetConfig);
+    scheduler.attachEvent("onSchedulerResize", resetConfig);
 
+    // we do not allow changes to the source calendar
     scheduler.config.readonly = true;
     /* Add a red line at the current time.
      * see https://docs.dhtmlx.com/scheduler/api__scheduler_hour_date_config.html

--- a/templates/calendars/dhtmlx.html
+++ b/templates/calendars/dhtmlx.html
@@ -35,32 +35,7 @@
     <body>
         <div id="scheduler_here" class="dhx_cal_container"
             style='width:100%; height:100%;'>
-            <div class="dhx_cal_navline">
-                {%- if "previous" in specification["controls"] -%}
-                <div class="dhx_cal_prev_button">&nbsp;</div>
-                {%- endif -%}
-                {%- if "next" in specification["controls"] -%}
-                <div class="dhx_cal_next_button">&nbsp;</div>
-                {%- endif -%}
-                {%- if "today" in specification["controls"] -%}
-                <div class="dhx_cal_today_button"></div>
-                {%- endif -%}
-                {%- if "date" in specification["controls"] -%}
-                <div class="dhx_cal_date"></div>
-                {%- endif -%}
-                {%- if "day" in specification["tabs"] -%}
-                <div class="dhx_cal_tab" name="day_tab"></div>
-                {%- endif -%}
-                {%- if "week" in specification["tabs"] -%}
-                <div class="dhx_cal_tab" name="week_tab"></div>
-                {%- endif -%}
-                {%- if "month" in specification["tabs"] -%}
-                <div class="dhx_cal_tab" name="month_tab"></div>
-                {%- endif -%}
-                {%- if "agenda" in specification["tabs"] -%}
-                <div class="dhx_cal_tab" name="agenda_tab" id="agenda_tab"></div>
-                {%- endif -%}
-            </div>
+            <div class="dhx_cal_navline"></div>
             <div class="dhx_cal_header"></div>
             <div class="dhx_cal_data"></div>
         </div>

--- a/templates/calendars/dhtmlx.html
+++ b/templates/calendars/dhtmlx.html
@@ -8,6 +8,7 @@
             var specification = {{ specification | tojson | safe }};
         </script>
         <!-- scheduler -->
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <script src="js/dhtmlx/dhtmlxscheduler.js"
             charset="utf-8"></script>
         <script src="js/configure.js"


### PR DESCRIPTION
This contributes to #101 

![image](https://github.com/niccokunzmann/open-web-calendar/assets/564768/987b48bd-35bc-4487-a172-4251a41e5b58)


- expose compact_layout_width parameter
- test for small browser (iPhone)
- allow setting the window size in behave tests
- test header buttons configurability
- resize scheduler if window changes]
- remove tooltip overlap with quick info if on touch screen
- set viewport



before and after images:
<img src="https://github.com/niccokunzmann/open-web-calendar/assets/564768/cbd23a5a-bdc5-49cd-9fa9-aa3fc9b21dba" width=40%/> <img src="https://github.com/niccokunzmann/open-web-calendar/assets/564768/f305ddf9-fb5f-4ecc-aaac-d65a042c5473" width=40%/>


