### PR TITLE
Fix the time format UI by adding a leading zero

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -93,7 +93,7 @@
                         <option value="%g:%i %a">am/pm - 1:15 am, 1:45 pm</option>
                         <option value="%h:%i %a">am/pm - 01:15 am, 1:45 pm</option>
                         <option value="%g:%i %A">AM/PM - 1:15 AM, 1:45 PM</option>
-                        <option value="%h:%i %A">AM/PM - 01:15 AM, 1:45 PM</option>
+                        <option value="%h:%i %A">AM/PM - 01:15 AM, 01:45 PM</option>
                     </select>
                 </p>
                 <h3>{{ html("language-title") }}</h3>


### PR DESCRIPTION
There was a spelling mistake in the dropdown menu.