### PR TITLE
Make text scale with viewport width on small screens

### DIFF
--- a/static/css/dhtmlx/style.css
+++ b/static/css/dhtmlx/style.css
@@ -96,3 +96,16 @@ div.dhx_agenda_line > span {
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
+
+@media only screen and (max-width: 480px) {
+    .event {
+        height: 4.17vw;
+        font-size: 2.92vw;
+    }
+
+    .dhx_month_head {
+        height: 6.5vw;
+        font-size: 2.5vw;
+        line-height: 3.75vw;
+    }
+}


### PR DESCRIPTION
This is my implementation of what we discussed in #101. 
Along with the events, I also applied the same treatment to the month headers. I didn't touch the calendar header, as I think the buttons should stay somewhat large to be usable. 

It's probably not perfect. I hope `style.css` was the right file to insert my CSS. I calculated the size values so that they do not change at 480px width, which is where the layout changes. 

I wasn't sure where the `.event` class comes from. Is it fine to use it for this?

And finally two quick screenshots for comparison: 

![old](https://github.com/niccokunzmann/open-web-calendar/assets/144177788/c3017f4f-b447-4259-a4bd-5546c0361eb4)
![new](https://github.com/niccokunzmann/open-web-calendar/assets/144177788/1eab1178-2743-41dc-9a7c-c5fb431406ff)
