### PR TITLE
Allow subscribing to pages with alternate links to calendars

### DIFF
--- a/features/calendars/one-day-event.html
+++ b/features/calendars/one-day-event.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <link rel="alternate" hreflang="de" href="/one-day-event.html?language=de" />
+  <link rel="alternate" type="text/calendar" title="Event Calendar" href="./one-day-event.ics" />
+</head>
+<body>
+
+<h1>This is for only one event!</h1>
+<p>test1 starts at 4th March at 7am</p>
+
+</body>
+</html>

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -67,9 +67,10 @@ def calendar_urls():
     """
     mapping = {}
     for file in os.listdir(CALENDAR_DIRECTORY):
+        url = "http://test.examples.local/" + file
+        with open(os.path.join(CALENDAR_DIRECTORY, file)) as f:
+            cache_url(url, f.read())
+        mapping[file] = url
         if file.lower().endswith(".ics"):
-            url = "http://test.examples.local/" + file
-            with open(os.path.join(CALENDAR_DIRECTORY, file)) as f:
-                cache_url(url, f.read())
             mapping[file[:-4]] = url
     return mapping

--- a/test/test_issue_309_extract_ics_feed.py
+++ b/test/test_issue_309_extract_ics_feed.py
@@ -1,0 +1,13 @@
+"""We want to be able to subscribe from sites that provide ICS links indirectly.
+
+See https://github.com/niccokunzmann/open-web-calendar/issues/309
+"""
+
+def test_request_from_alternate_link(client, calendar_urls):
+    """If we request from an alternate link, we should see the events from the calendar.
+
+    The HTML page links to the ics file.
+    """
+    calendar_text = client.get(f"/calendar.ics?url={calendar_urls['one-day-event']}").text
+    html_text = client.get(f"/calendar.ics?url={calendar_urls['one-day-event.html']}").text
+    assert calendar_text == html_text, "Whether alternate link or direct, the content should be the same."


### PR DESCRIPTION
This should fix #309.

Pages that include an alternate link will show up correctly.