### PR TITLE
Update dhtmlx.html

### DIFF
--- a/templates/calendars/dhtmlx.html
+++ b/templates/calendars/dhtmlx.html
@@ -5,7 +5,7 @@ SPDX-License-Identifier: GPL-2.0-only
 -->
 
 <!DOCTYPE html>
-<html>
+<html lang="{{ specification['language'] }}">
     <!-- Mostly copied from https://docs.dhtmlx.com/scheduler/howtostart_nodejs.html#step2addingschedulertothepage -->
     <head>
         <title>{{ specification["title"] | safe }}</title>


### PR DESCRIPTION
WCAG 3.1.1: Ensures every HTML document has a lang attribute (html) #347

- https://github.com/niccokunzmann/open-web-calendar/blob/master/templates/calendars/dhtmlx.html would need it too.