### PR TITLE
Remove security issue: host injection warning (by adding ALLOWED_HOSTS)

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,6 +6,7 @@
 
 from flask import Flask, render_template, make_response, request, jsonify, \
     redirect, send_from_directory, Response
+from flask_allowedhosts import limit_hosts
 from flask_caching import Cache
 import json
 import os
@@ -29,6 +30,7 @@ import mimetypes
 DEBUG = os.environ.get("APP_DEBUG", "true").lower() == "true"
 PORT = int(os.environ.get("PORT", "5000"))
 CACHE_REQUESTED_URLS_FOR_SECONDS = int(os.environ.get("CACHE_REQUESTED_URLS_FOR_SECONDS", 600))
+ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS")
 
 # constants
 HERE = os.path.dirname(__file__) or "."
@@ -161,6 +163,7 @@ def get_specification(query=None):
         if len(value) == 1 and type(specification.get(parameter)) != list:
             value = value[0]
         specification[parameter] = value
+
     return specification
 
 
@@ -178,6 +181,7 @@ def render_app_template(template, specification):
     )
 
 @app.route("/calendar.<type>", methods=['GET', 'OPTIONS'])
+@limit_hosts(allowed_hosts=ALLOWED_HOSTS)
 # use query string in cache, see https://stackoverflow.com/a/47181782/1320237
 #@cache.cached(timeout=CACHE_TIMEOUT, query_string=True)
 def get_calendar(type):
@@ -211,20 +215,24 @@ for folder_name in os.listdir(STATIC_FOLDER_PATH):
 
 @app.route("/")
 @app.route("/index.html")
+@limit_hosts(allowed_hosts=ALLOWED_HOSTS)
 def serve_index():
     specification = get_specification()
     return render_app_template("index.html", specification)
 
 @app.route("/about.html")
+@limit_hosts(allowed_hosts=ALLOWED_HOSTS)
 def serve_about():
     specification = get_specification()
     return render_app_template("about.html", specification)
 
 @app.route("/configuration.js")
+@limit_hosts(allowed_hosts=ALLOWED_HOSTS)
 def serve_configuration():
     return make_js_file_response("/* generated */\nconst configuration = {};".format(json.dumps(get_configuration())))
 
 @app.route("/locale_<lang>.js")
+@limit_hosts(allowed_hosts=ALLOWED_HOSTS)
 def serve_locale(lang):
     """Serve the locale translations for the web frontend DHTMLX."""
     return make_js_file_response(render_template("locale.js", locale=json.dumps(translate.dhtmlx(lang), indent="  ")))

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 flask-caching
+flask-allowedhosts
 flask
 icalendar
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,8 @@ flask==3.0.3
     # via
     #   -r requirements.in
     #   flask-caching
+flask-allowedhosts==1.2.0
+    # via -r requirements.in
 flask-caching==2.3.0
     # via -r requirements.in
 gunicorn==22.0.0


### PR DESCRIPTION
I was warned by a Pen Tester:

"Hello there, I found a Host Header Injection security hole, in simple terms Host Header Injection is a weakness where users can change or redirect to any host, this will have an impact if the website has features such as Password Reset, Registration, and features that send emails or the like, My advice for the future when developers create web applications, do validation on the Host header so that it cannot be manipulated.

Title: Host Header Poisoning
Type: Injection / Missconfiguration

Proof of concept
1. I did subdomain enumeration and got the owc website subdomain
2. When making a GET request to the website I intercept the request using the Burp Suite tool and then change the Host header to evil.com
3. Then the website redirects to the evil.com website, and all source domains change to evil.com

- https://portswigger.net/web-security/host-header
- https://hackerone.com/reports/1098948"