### PR TITLE
Update changelog.md

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ These correspond to the [tags]({{link.tags}}).
 The latest version might not be released, yet.
 
 - v1.34
+    -Ensures every HTML document has a lang attribute (html) #347 (https://github.com/niccokunzmann/open-web-calendar/issues/347)
     - Allow hosters to close the Host Header Injection vulnerability, see [PR 366](https://github.com/niccokunzmann/open-web-calendar/pull/366)
 - v1.33
     - Update dependencies


### PR DESCRIPTION
WCAG 3.1.1: Ensures every HTML document has a lang attribute (html) #347