### PR TITLE
Week example css fix

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -43,7 +43,8 @@ function updateCalendarInputs() {
         color.type = "color";
         color.classList.add("color-input");
         color.value = "#fefefe";
-        color.setAttribute("cssTemplate", ".CALENDAR-INDEX-" + calendar_index + " { background-color: {color}; }")
+        var cssTemplate = ".CALENDAR-INDEX-" + calendar_index + ", .CALENDAR-INDEX-" + calendar_index + " .dhx_body, .CALENDAR-INDEX-" + calendar_index + " .dhx_title  { background-color: {color}; } \n";
+        color.setAttribute("cssTemplate", cssTemplate);
         color.addEventListener("change", updateUrls);
         color.addEventListener("keyup", updateUrls);
         li.appendChild(color);


### PR DESCRIPTION
This fixes the CSS of the categories so that they reflect the style of the calendar.

![image](https://github.com/niccokunzmann/open-web-calendar/assets/564768/db1748a4-72a3-4aa0-b91d-5aeecade1fa1)
