### PR TITLE
Revert "Bump mkdocs-rss-plugin in the pip-requirements group"

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -91,7 +91,7 @@ mkdocs-mdpo-plugin @ git+https://github.com/niccokunzmann/mkdocs-mdpo-plugin.git
     # via -r docs-requirements.in
 mkdocs-meta-descriptions-plugin==3.0.0
     # via -r docs-requirements.in
-mkdocs-rss-plugin==1.13.1
+mkdocs-rss-plugin==1.12.2
     # via -r docs-requirements.in
 packaging==24.0
     # via
@@ -137,9 +137,7 @@ pyyaml-env-tag==0.1
 regex==2024.4.16
     # via mkdocs-material
 requests==2.31.0
-    # via
-    #   mkdocs-material
-    #   mkdocs-rss-plugin
+    # via mkdocs-material
 six==1.16.0
     # via python-dateutil
 smmap==5.0.1


### PR DESCRIPTION
This reverts commit d768d3f5a0b0fabe21de3e22c612746e74b64581.

See https://github.com/Guts/mkdocs-rss-plugin/issues/299

To test:

- clone the repo
- run `tox -e docs -- serve`

You can run the same before this commit and see that it cannot serve the content.