### PR TITLE
Show proper tag for normal docker release and dev version on master

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -113,8 +113,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade build
-          # add commit hash to build information
-          sed -i 's/^local_scheme/#local_scheme/g' pyproject.toml
+          if [ "$GITHUB_REF_NAME" == "master" ]; then
+            echo "Adding commit hash to build information"
+            sed -i 's/^local_scheme/#local_scheme/g' pyproject.toml
+          else
+            echo "Using version information from tag"
+          fi
           python -m build
     
       - name: Set up QEMU


### PR DESCRIPTION
This will improve version information for docker tag :latest