### PR TITLE
Fix : allow use of subfolders in the url with reverse proxies

### DIFF
--- a/open_web_calendar/static/js/common.js
+++ b/open_web_calendar/static/js/common.js
@@ -5,7 +5,13 @@
 /*
  * Common functions.
  */
-const DEFAULT_URL = document.location.protocol + "//" + document.location.host;
+url = new URL(document.location.href);
+if (url.pathname == "/") {
+    pathname = "";
+} else {
+    pathname = url.pathname;
+}
+const DEFAULT_URL = url.origin + pathname;
 const CALENDAR_ENDPOINT = "/calendar.html";
 
 

--- a/open_web_calendar/static/js/common.js
+++ b/open_web_calendar/static/js/common.js
@@ -10,6 +10,15 @@ if (url.pathname == "/") {
     pathname = "";
 } else {
     pathname = url.pathname;
+    // delete the last part of the path if html page
+    var parts = pathname.split("/");
+    var lastPart = parts[parts.length - 1];
+    if (lastPart.endsWith(".html")) {
+        pathname = pathname.substring(0, pathname.length - lastPart.length);
+    }
+}
+if (pathname.endsWith("/")) {
+    pathname = pathname.substring(0, pathname.length - 1);
 }
 const DEFAULT_URL = url.origin + pathname;
 const CALENDAR_ENDPOINT = "/calendar.html";

--- a/open_web_calendar/templates/about.html
+++ b/open_web_calendar/templates/about.html
@@ -11,7 +11,7 @@ SPDX-License-Identifier: GPL-2.0-only
         <title>{{ specification["title"] | safe }}</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <link rel="icon" type="image/x-icon" href="{{ specification["favicon"] }}">
-        <link rel="alternate" type="text/calendar" href="/calendar.ics{{ get_query_string() }}" />
+        <link rel="alternate" type="text/calendar" href="calendar.ics{{ get_query_string() }}" />
         <link href="css/index.css"
             rel="stylesheet" type="text/css" charset="utf-8">
 
@@ -25,17 +25,17 @@ SPDX-License-Identifier: GPL-2.0-only
     </head>
     <body>
         <header>
-            <a href="/calendar.html{{ get_query_string() | safe }}"><h1>{{ specification["title"] | safe }}</h1></a>
+            <a href="calendar.html{{ get_query_string() | safe }}"><h1>{{ specification["title"] | safe }}</h1></a>
         </header>
         <main>
             <p class="description">
                 {{ specification["description"] or html("description") }}
             </p>
             <ul>
-                <li><a href="/calendar.html{{ get_query_string() | safe }}">{{ html("links-website") }}</a></li>
-                <li><a href="/calendar.ics{{ get_query_string() | safe }}">{{ html("links-ics") }}</a></li>
-                <li><a href="/calendar.spec{{ get_query_string() | safe }}">{{ html("links-spec") }}</a></li>
-                <li><a href="/index.html{{ get_query_string() | safe }}">{{ html("links-edit") }}</a></li>
+                <li><a href="calendar.html{{ get_query_string() | safe }}">{{ html("links-website") }}</a></li>
+                <li><a href="calendar.ics{{ get_query_string() | safe }}">{{ html("links-ics") }}</a></li>
+                <li><a href="calendar.spec{{ get_query_string() | safe }}">{{ html("links-spec") }}</a></li>
+                <li><a href="index.html{{ get_query_string() | safe }}">{{ html("links-edit") }}</a></li>
                 <li>
                     {{ html("timezone-choice") }}
                     <select id="select-timezone" onchange="loadCalendarInDifferentTimeZone()">

--- a/open_web_calendar/templates/calendars/dhtmlx.html
+++ b/open_web_calendar/templates/calendars/dhtmlx.html
@@ -10,7 +10,7 @@ SPDX-License-Identifier: GPL-2.0-only
     <head>
         <title>{{ specification["title"] | safe }}</title>
         <meta charset="utf-8">
-        <link rel="alternate" type="text/calendar" href="/calendar.ics{{ get_query_string() }}" />
+        <link rel="alternate" type="text/calendar" href="calendar.ics{{ get_query_string() }}" />
         <script type="text/javascript">
             var specification = {{ specification | tojson | safe }};
         </script>
@@ -64,7 +64,7 @@ SPDX-License-Identifier: GPL-2.0-only
         </div>
         <div class="status-window">
             <a class="item" id="errorStatusIcon" href="javascript:toggleErrorWindow();">!</a>
-            <a class="item" id="infoIcon" href="/about.html{{ get_query_string() | safe }}" target="{{ specification['target'] }}">?</a>
+            <a class="item" id="infoIcon" href="about.html{{ get_query_string() | safe }}" target="{{ specification['target'] }}">?</a>
         </div>
     </body>
 </html>

--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -9,7 +9,7 @@ SPDX-License-Identifier: GPL-2.0-only
     <head>
         <title>Open Web Calendar</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <link rel="alternate" type="text/calendar" href="/calendar.ics{{ get_query_string() }}" />
+        <link rel="alternate" type="text/calendar" href="calendar.ics{{ get_query_string() }}" />
         <script type="text/javascript">
             const specification = {{ specification | tojson | safe }};
             const language = {{ language | tojson | safe }};
@@ -21,7 +21,7 @@ SPDX-License-Identifier: GPL-2.0-only
         <script src="js/common.js"></script>
         <script src="configuration.js"></script>
         {%- for name, code, percent in configuration["index"]["languages"]: %}
-            <link rel="alternate" hreflang="{{code}}" href="/index.html?language={{code}}" />
+            <link rel="alternate" hreflang="{{code}}" href="index.html?language={{code}}" />
         {%- endfor %}
     </head>
     <body>
@@ -37,7 +37,7 @@ SPDX-License-Identifier: GPL-2.0-only
             <div class="section languages">
                 <p>
                     {%- for name, code, percent in configuration["index"]["languages"]: %}
-                        <a class="{{ ('current' if code == specification['language'] else '') }}" href="/index.html?language={{code}}">{{ name }}
+                        <a class="{{ ('current' if code == specification['language'] else '') }}" href="index.html?language={{code}}">{{ name }}
                         {%- if percent != 100 -%}
                             ({{percent}}%)
                         {% endif -%}


### PR DESCRIPTION
This fix allow to use owc behind a reverse proxy using a subfolder in the url.
Ex : `https://www.domain.fr/owc/`

The index page generates all the paths correctly. t also works with urls without subfolders.
Ex : `https://owc.domain.fr`