### PR TITLE
fix links to GitHub that still point to the old source location

### DIFF
--- a/docs/host/configure.md
+++ b/docs/host/configure.md
@@ -68,7 +68,7 @@ There are loads more values that can be changed.
 Please refer to the [default_specification.yml].
 These values are all documented.
 
-[default_specification.yml]: https://github.com/niccokunzmann/open-web-calendar/blob/master/default_specification.yml
+[default_specification.yml]: https://github.com/niccokunzmann/open-web-calendar/blob/master/open_web_calendar/default_specification.yml
 [privacy-policy]: ../privacy-policy
 
 See also:

--- a/open_web_calendar/translations/ar/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/ar/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/be/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/be/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/ca/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/ca/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/cs/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/cs/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/cy/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/cy/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/da/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/da/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/de/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/de/LC_MESSAGES/dev/api.md.po
@@ -227,10 +227,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**specification_url** If you specify this query parameter, the editor "

--- a/open_web_calendar/translations/el/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/el/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/en/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/en/LC_MESSAGES/dev/api.md.po
@@ -193,10 +193,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**specification_url** If you specify this query parameter, the editor "

--- a/open_web_calendar/translations/eo/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/eo/LC_MESSAGES/dev/api.md.po
@@ -278,10 +278,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid "![architecture](/assets/img/architecture.svg)"
 msgstr "![arĥitekturo](/assets/img/architecture.svg)"

--- a/open_web_calendar/translations/es/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/es/LC_MESSAGES/dev/api.md.po
@@ -273,10 +273,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid "![architecture](/assets/img/architecture.svg)"
 msgstr "![architecture](/assets/img/architecture.svg)"

--- a/open_web_calendar/translations/fi/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/fi/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/fr/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/fr/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/he/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/he/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/hr/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/hr/LC_MESSAGES/dev/api.md.po
@@ -229,10 +229,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/hu/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/hu/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/id/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/id/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/it/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/it/LC_MESSAGES/dev/api.md.po
@@ -213,10 +213,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/ja/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/ja/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/ko/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/ko/LC_MESSAGES/dev/api.md.po
@@ -204,10 +204,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**specification_url** If you specify this query parameter, the editor "

--- a/open_web_calendar/translations/ko_LAVA/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/ko_LAVA/LC_MESSAGES/dev/api.md.po
@@ -204,10 +204,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**specification_url** If you specify this query parameter, the editor "

--- a/open_web_calendar/translations/nb_NO/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/nb_NO/LC_MESSAGES/dev/api.md.po
@@ -193,10 +193,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**specification_url** If you specify this query parameter, the editor "

--- a/open_web_calendar/translations/nl/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/nl/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/pl/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/pl/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/pt/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/pt/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/ro/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/ro/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/ru/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/ru/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/si/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/si/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/sk/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/sk/LC_MESSAGES/dev/api.md.po
@@ -275,10 +275,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid "![architecture](/assets/img/architecture.svg)"
 msgstr "![architecture](/asets/img/architecture.svg)"

--- a/open_web_calendar/translations/sv/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/sv/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/th/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/th/LC_MESSAGES/dev/api.md.po
@@ -211,10 +211,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**specification_url** If you specify this query parameter, the editor "

--- a/open_web_calendar/translations/tr/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/tr/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/uk/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/uk/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "

--- a/open_web_calendar/translations/zh_Hans/LC_MESSAGES/dev/api.md.po
+++ b/open_web_calendar/translations/zh_Hans/LC_MESSAGES/dev/api.md.po
@@ -217,10 +217,10 @@ msgstr ""
 #, fuzzy
 msgid ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 msgstr ""
 "[default_specification]: https://github.com/niccokunzmann/open-web-"
-"calendar/tree/master//default_specification.yml"
+"calendar/tree/master/open_web_calendar/default_specification.yml"
 
 msgid ""
 "**Query parameters** All parameters to the calendar url are put into the "


### PR DESCRIPTION
Not sure I got all of them, I noticed this in a lot of places.