### PR TITLE
use flask-allowed-hosts instead of flask-allowedhosts in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ classifiers = [
 
 dependencies = [
     "flask-caching",
-    "flask-allowedhosts",
+    "flask-allowed-hosts",
     "flask",
     "icalendar",
     "requests",


### PR DESCRIPTION
Looks like the old name got unpublished from Pypi?

I can only find this one: https://pypi.org/project/flask-allowed-hosts/