### PR TITLE
Add and document JS hook

### DIFF
--- a/docs/dev/api.md
+++ b/docs/dev/api.md
@@ -141,6 +141,10 @@ If you add a new parameter as a developer:
 In the [template][dhtmlx-23] you can access the specification through the `specification` variable.
 The specification is available to JavaScript as the `specification` variable.
 
+See also:
+
+- [JavaScript Customization](../javascript)
+
 
 [app.py-81]: https://github.com/niccokunzmann/open-web-calendar/blob/85a72dab4561e250aec69b5ad7c3de074eefa1e8/app.py#L81
 [dhtmlx-23]: https://github.com/niccokunzmann/open-web-calendar/blob/85a72dab4561e250aec69b5ad7c3de074eefa1e8/templates/calendars/dhtmlx.html#L23

--- a/docs/dev/javascript.md
+++ b/docs/dev/javascript.md
@@ -1,0 +1,52 @@
+---
+# SPDX-FileCopyrightText: 2024 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+comments: true
+description: "The calendar can be customized with JavaScript."
+---
+
+# JavaScript Customization
+
+The Open Web Calendar can be modified with JavaScript.
+For this, two [parameters] are available:
+
+- `javascript=...` for adding JavaScript to the calendar.
+- `javascript_url=...` for loading JavaScript from a URL.
+
+[parameters]: ../api
+
+Anything that is added to the `javascript` parameter is executed after the calendar has been loaded.
+Thus, you can access the calendar and choose change its configuration.
+
+## Useful Variables
+
+When executing JavaScript, the stable variables and functions are listed below.
+More functions and variables are available but if they are not documented here, they can change.
+
+### `onCalendarInitialized`
+
+The `onCalendarInitialized()` function is called after the calendar is fully configured.
+You can override the configuration of the calendar at this point.
+After this is called, the events are loaded into the calendar.
+The content of this function can be modified with the JavaScript parameter `javascript=...`.
+
+### `scheduler`
+
+The `scheduler` variable contains the [DHTMLX Scheduler] object.
+Here are some links to the API documentation:
+
+- [DHTMLX Scheduler]
+- [Properties](https://docs.dhtmlx.com/scheduler/api__refs__scheduler_props.html)
+- [Sizes](https://docs.dhtmlx.com/scheduler/api__scheduler_xy_other.html)
+
+### `specification`
+
+The `specification` variable contains the full specification of the calendar with all [parameters] including your own and those defined for all calendars.
+
+See also:
+
+- [parameters]
+
+[DHTMLX Scheduler]: https://docs.dhtmlx.com/scheduler/api__refs__scheduler.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -263,6 +263,7 @@ nav:
     - dev/translate.md
     - dev/index.md
     - dev/api.md
+    - dev/javascript.md
     - dev/maintain.md
     - dev/license.md
   - SECURITY.md

--- a/open_web_calendar/static/js/configure.js
+++ b/open_web_calendar/static/js/configure.js
@@ -399,6 +399,7 @@ function loadCalendar() {
 
     //requestJSON(schedulerUrl, loadEventsOnSuccess, loadEventsOnError);
     scheduler.setLoadMode("day");
+    onCalendarInitialized();
     scheduler.load(schedulerUrl, "json");
 
 
@@ -409,6 +410,8 @@ function loadCalendar() {
 
     setLoader();
 }
+
+var onCalendarInitialized = onCalendarInitialized || function() {};
 
 /* Agenda view
  *

--- a/open_web_calendar/templates/calendars/dhtmlx.html
+++ b/open_web_calendar/templates/calendars/dhtmlx.html
@@ -49,7 +49,11 @@ SPDX-License-Identifier: GPL-2.0-only
         {% for link in specification.javascript_url %}
         <script src="{{ link }}" charset="utf-8"></script>
         {% endfor %}
-        <script type="text/javascript">{{ specification.javascript | replace('</script', '</scr\\ipt') | safe }}</script>
+        <script type="text/javascript">
+            function onCalendarInitialized() {
+                {{ specification.javascript | replace('</script', '</scr\\ipt') | safe }}
+            };
+        </script>
     </head>
     <body>
         <div id="scheduler_here" class="dhx_cal_container"


### PR DESCRIPTION
This documents the JS hook and executed it after the scheduler has been initialized.

This should provide a solution to #625.
Fixes #632.