### PR TITLE
Describe how to use the squid proxy server

### DIFF
--- a/docs/host/configure.md
+++ b/docs/host/configure.md
@@ -164,14 +164,30 @@ default `true`, values `true` or `false`, always `false` in the Docker container
 
 Set the debug flag for the app.
 
-### Further Configuration
+## Further Configuration
 
 The Open Web Calendar uses libraries whose behavior can be further customized.
 
 - **Flask** has **[more environment variables](https://flask.palletsprojects.com/en/3.0.x/config/)** available to configure how the application serves content.
 - **Requests** is used the get the `.ics` files. You can [configure a proxy](#ssrf-protection-with-a-proxy-server).
 
-### SSRF Protection with a Proxy Server
+The Open Web Calendar relies on proxy servers for these features:
+
+- **Access Control and Users**
+  To restrict who can use the Open Web Calendar, you can use `nginx` or `apache` as a reverse proxy in front of it.
+  YuNoHost is another self-hosting option to restrict access.
+- **HTTPS Encryption**  
+  This can be done by `nginx`, `apache` or `caddy`.
+- **More Advanced Caching**  
+  Basic caching is handeled by the Open Web Calendar.
+  For more advanced cache configuration, use a proxy server like `squid`.
+  Have a look in the documentation below on how to make the Open Web Calendar access the web only through a proxy.
+- **Restricting Access to Calendars**
+  By default, the Open Web Calendar does not restrict which calendars to show.
+  Use the proxy server to filter the calendars.
+  If you run the Open Web Calendar behind a firewall with other web services, setting up a proxy is necessary to protect from SSRF attacks.
+
+## SSRF Protection with a Proxy Server
 
 The Open Web Calendar can be used to access the local network behind a firewall,
 see [Issue 250](https://github.com/niccokunzmann/open-web-calendar/issues/250).
@@ -190,3 +206,58 @@ export ALL_PROXY="socks5://10.10.1.10:3434"
 See also:
 
 - [Prevent SSRF using a Tor proxy](../docker#preventing-ssrf-attacks-using-a-tor-proxy)
+
+## Squid as a Proxy Server
+
+The [Squid] Proxy and Cache is flexible and configurable.
+You can use it in front of the Open Web Calendar to configure access and customize caching.
+
+!!! note "Operating System"
+
+    Squid is avaiable for all major platforms.
+    For the commands and paths of this tutorial, we assume you run Squid on Debain/Ubuntu.
+    The commands might work on other systems, but that is not tested.
+
+After you have installed the [Squid] Proxy, add this file into the  `conf.d` directory.
+Squid will load it automatically then.
+
+In Linux, create `/etc/squid/conf.d/open-web-calendar.conf`:
+
+```sh
+--8<-- "squid/open-web-calendar.conf"
+```
+
+The list above denies the Open Web Calendar access to all known local/internal networks.
+If you have your own local network (IPv4 or IPv6), add it to the list above to be sure.
+
+On Linux, you can install the file with this command:
+
+```sh
+sudo wget -O /etc/squid/conf.d/open-web-calendar.conf https://raw.githubusercontent.com/niccokunzmann/open-web-calendar/master/docs/snippets/squid/open-web-calendar.conf
+```
+
+Then, restart the squid proxy.
+
+```sh
+sudo service squid reload
+```
+
+Set the environment variables to tell the Open Web Calendar to use the Squid proxy installed on `localhost`.
+Setting this variable changes depending on how you run the Open Web Calendar.
+
+If you use the [Python Setup](../pypi), you can set the environment variables for the server like this:
+
+```sh
+export HTTP_PROXY="http://localhost:3128"
+export HTTPS_PROXY="http://localhost:3128"
+export ALL_PROXY="http://localhost:3128"
+gunicorn open_web_calendar:app
+```
+
+When you try to access a forbidden calendar with the local `open-web-calendar`,
+e.q. `http://172.16.0.1/calendar.ics`, you will see this error message:
+
+> 403 Client Error: Forbidden for url: http://172.16.0.1/calendar.ics
+
+[1]: ../pypi
+[Squid]: https://www.squid-cache.org/

--- a/docs/snippets/docker/docker-compose.yml
+++ b/docs/snippets/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  open-web-calendar:
+    image: niccokunzmann/open-web-calendar
+    restart: unless-stopped
+    environment:
+      - HTTP_PROXY=http://squid-container:3128
+      - HTTPS_PROXY=http://squid-container:3128
+      - ALL_PROXY=http://squid-container:3128
+
+  # see https://hub.docker.com/r/ubuntu/squid
+  squid-container:
+    image: ubuntu/squid
+    environment:
+      - TZ=UTC
+    volumes:
+      - ./open-web-calendar.conf:/etc/squid/conf.d/00-open-web-calendar.conf

--- a/docs/snippets/docker/open-web-calendar.conf
+++ b/docs/snippets/docker/open-web-calendar.conf
@@ -1,0 +1,25 @@
+## Example rule to deny access to your local networks.
+## Adapt to list your (internal) IP networks from where browsing
+## should be allowed
+acl owc_forbidden dst 0.0.0.1-0.255.255.255  # RFC 1122 "this" network (LAN)
+acl owc_forbidden dst 10.0.0.0/8             # RFC 1918 local private network (LAN)
+acl owc_forbidden dst 100.64.0.0/10          # RFC 6598 shared address space (CGN)
+acl owc_forbidden dst 169.254.0.0/16         # RFC 3927 link-local (directly plugged) machines
+acl owc_forbidden dst 172.16.0.0/12          # RFC 1918 local private network (LAN)
+acl owc_forbidden dst 192.168.0.0/16         # RFC 1918 local private network (LAN)
+acl owc_forbidden dst fc00::/7               # RFC 4193 local private network range
+acl owc_forbidden dst fe80::/10              # RFC 4291 link-local (directly plugged) machines
+
+## If the Open Web Calendar runs on another machine, not localhost (127.0.0.1),
+## fill in the network or IP of that machine here and allow access from it.
+# acl owc_host src 127.0.0.1           # Allow Access to Squid from localhost (default)
+acl owc_host src 172.16.0.0/12     # Uncomment if you run the Open Web Calendar as a docker service
+
+## Access from owc_host is allowed to all but forbidden networks
+http_access allow owc_host !owc_forbidden
+http_access deny all
+
+## Use IPv4 for DNS
+## See https://superuser.com/a/1443889
+dns_v4_first on
+

--- a/docs/snippets/squid/open-web-calendar.conf
+++ b/docs/snippets/squid/open-web-calendar.conf
@@ -1,0 +1,23 @@
+## Example rule to deny access to your local networks.
+## Adapt to list your (internal) IP networks from where browsing
+## should be allowed
+acl owc_forbidden dst 0.0.0.1-0.255.255.255  # RFC 1122 "this" network (LAN)
+acl owc_forbidden dst 10.0.0.0/8             # RFC 1918 local private network (LAN)
+acl owc_forbidden dst 100.64.0.0/10          # RFC 6598 shared address space (CGN)
+acl owc_forbidden dst 169.254.0.0/16         # RFC 3927 link-local (directly plugged) machines
+acl owc_forbidden dst 172.16.0.0/12          # RFC 1918 local private network (LAN)
+acl owc_forbidden dst 192.168.0.0/16         # RFC 1918 local private network (LAN)
+acl owc_forbidden dst fc00::/7               # RFC 4193 local private network range
+acl owc_forbidden dst fe80::/10              # RFC 4291 link-local (directly plugged) machines
+
+## If the Open Web Calendar runs on another machine, not localhost (127.0.0.1),
+## fill in the network or IP of that machine here and allow access from it.
+acl owc_host src 127.0.0.1           # Allow Access to Squid from localhost (default)
+# acl owc_host src 172.16.0.0/12     # Uncomment if you run the Open Web Calendar as a docker service
+
+## Access from owc_host is allowed to all but forbidden networks
+http_access allow owc_host !owc_forbidden
+
+## Use IPv4 for DNS
+## See https://superuser.com/a/1443889
+dns_v4_first on

--- a/docs/snippets/tor/docker-compose.yml
+++ b/docs/snippets/tor/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  tor-open-web-calendar:
+    image: niccokunzmann/open-web-calendar:master
+    restart: unless-stopped
+    environment:
+    # use socks5h for *.onion
+    # see https://stackoverflow.com/a/42972942/1320237
+      - HTTP_PROXY=socks5h://tor-socks-proxy:9150
+      - HTTPS_PROXY=socks5h://tor-socks-proxy:9150
+      - ALL_PROXY=socks5h://tor-socks-proxy:9150
+      - ALLOWED_HOSTS=
+    # optional: create a private network so OWC cannot access the Internet directly
+    networks:
+      - no-internet-only-tor
+
+  # from https://hub.docker.com/r/peterdavehello/tor-socks-proxy/
+  tor-socks-proxy:
+    image: peterdavehello/tor-socks-proxy # use :test for arm64
+    restart: unless-stopped
+    # optional: allow access to OWC and the Internet
+    networks:
+      - default
+      - no-internet-only-tor
+
+networks:
+  default:
+    ipam:
+      driver: default
+  no-internet-only-tor: # see https://stackoverflow.com/a/51964169/1320237
+    driver: bridge
+    internal: true

--- a/open_web_calendar/app.py
+++ b/open_web_calendar/app.py
@@ -172,9 +172,11 @@ def get_text_from_url(url):
     """
     if __URL_CACHE:
         return __URL_CACHE[url]
-    return requests.get(
+    response = requests.get(
         url, headers=DEFAULT_REQUEST_HEADERS, timeout=REQUESTS_TIMEOUT
-    ).content
+    )
+    response.raise_for_status()
+    return response.content
 
 
 # @functools.cache

--- a/open_web_calendar/test/__main__.py
+++ b/open_web_calendar/test/__main__.py
@@ -18,7 +18,7 @@ from open_web_calendar.app import main
 HERE = Path(__file__).parent.absolute()
 CALENDAR_FOLDER = HERE.parent / "features" / "calendars"
 PORT = 8001
-HOST = "localhost"
+HOST = "0.0.0.0"
 
 
 class Handler(http.server.SimpleHTTPRequestHandler):

--- a/open_web_calendar/test/test_url_cache.py
+++ b/open_web_calendar/test/test_url_cache.py
@@ -20,6 +20,9 @@ from open_web_calendar.app import cache_url, get_text_from_url
 class MockRequestResult(NamedTuple):
     content: str
 
+    def raise_for_status(self):
+        pass
+
 
 def test_requests_are_automatically_cached(monkeypatch, mock):
     mock.return_value = MockRequestResult("trallala")

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,10 @@ commands =
     ruff check --fix
 
 [testenv:dev]
+passenv =
+    HTTP_PROXY
+    HTTPS_PROXY
+    ALL_PROXY
 deps = -e .[production]
 skip_install = True
 commands =


### PR DESCRIPTION
This aims to fix #250.

The changes added:

- create a nice error message for denied access
- allow configuring the proxy in development mode
- document the proxy setup with docker and local environment variables