### PR TITLE
Display the bottom navigation bar always

### DIFF
--- a/open_web_calendar/static/css/index.css
+++ b/open_web_calendar/static/css/index.css
@@ -33,10 +33,17 @@ body, .flexcontainer {
   color: var(--primary-color);
 }
 
-main, .navcontent {
+section, .navcontent {
     padding: 1em;
     margin-right: auto;
     margin-left: auto;
+}
+
+main {
+  margin-left: 0em;
+  margin-right: 0em;
+  display: flex;
+  flex-direction: column;
 }
 
 section {


### PR DESCRIPTION
This displays the bottom navigation bar always.

![grafik](https://github.com/user-attachments/assets/b01027f7-c77a-422a-a92c-f7791e3e5660)

Fixes #752 
