### PR TITLE
Remove navline if there are no controls

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,13 @@ The latest version might not be released, yet.
 <!-- Contributors, if you like to be linked, please put your name down here with a link. -->
 [தமிழ்நேரம்]: https://tamilneram.github.io/
 
+## v1.50
+
+- Free up space at the top of the calendar if there are no controls, see [Issue 753](https://github.com/niccokunzmann/open-web-calendar/issues/753)
+- Always display the bottom navigation bar, also in small screens, see [Issue 752](https://github.com/niccokunzmann/open-web-calendar/issues/752)
+- Update dependencies
+- Update Russian translation by Yurt Page, Ukrainian by Максим Горпиніч, German by Nicco Kunzmann, Finnish by Ricky Tigg, Tamil by [தமிழ்நேரம்], Greek by Dimitris B
+
 ## v1.49
 
 - Allow CalDAV sign-up, see [Issue 679](https://github.com/niccokunzmann/open-web-calendar/issues/679)

--- a/open_web_calendar/app.py
+++ b/open_web_calendar/app.py
@@ -212,7 +212,10 @@ def get_specification(query=None):
                 value[i] = False
             elif value[i] in ("true", "True"):
                 value[i] = True
-        if len(value) == 1 and not isinstance(specification.get(parameter), list):
+        if isinstance(specification.get(parameter), list):
+            if len(value) == 1 and value[0] == "":
+                value = []
+        elif len(value) == 1:
             value = value[0]
         specification[parameter] = value
 

--- a/open_web_calendar/static/css/dhtmlx/style.css
+++ b/open_web_calendar/static/css/dhtmlx/style.css
@@ -304,3 +304,14 @@ div.dhx_agenda_line > span {
     /* deactivate the tags in the week view */
     display: none;
 }
+
+.no-controls .dhx_cal_navline {
+    /* hide the navline if we have no controls */
+    display: none;
+}
+
+.no-controls {
+    /* hide the navline if we have no controls */
+    --dhx-scheduler-toolbar-height: 0px;
+}
+  

--- a/open_web_calendar/static/css/index.css
+++ b/open_web_calendar/static/css/index.css
@@ -13,7 +13,6 @@ body, .flexcontainer {
   flex: 1 1 auto;
 }
 
-
 .languages {
   text-align: center;
 }

--- a/open_web_calendar/static/js/configure.js
+++ b/open_web_calendar/static/js/configure.js
@@ -341,6 +341,7 @@ const actions = {
 const IS_TOUCH_SCREEN = window.matchMedia("(pointer: coarse)").matches;
 const CAN_HAVE_TOOLTIP = !IS_TOUCH_SCREEN;
 
+
 function loadCalendar() {
     /* Format the time of the hour.
      * see https://docs.dhtmlx.com/scheduler/settings_format.html
@@ -376,6 +377,13 @@ function loadCalendar() {
     // set the skin, scheduler v7
     // see https://docs.dhtmlx.com/scheduler/skins.html#dark
     scheduler.setSkin(getSkin());
+    /* Hide or display the header controls */
+    if (!specification.controls.length && !specification.tabs.length) {
+        document.body.classList.add("no-controls");
+    } else {
+        document.body.classList.remove("no-controls");
+    }
+
     // we do not allow changes to the source calendar
     scheduler.config.readonly = true;
     /* Add a red line at the current time.

--- a/open_web_calendar/test/test_specification.py
+++ b/open_web_calendar/test/test_specification.py
@@ -84,3 +84,10 @@ def test_boolean_values_of_parameters():
     assert spec["clean_html_embedded"] is True, "default"
     assert spec["clean_html_style"] is False
     assert spec["clean_html_links"] is True
+
+def test_empty_array():
+    spec = get_specification(
+        query=MultiDict({"tabs": "", "controls": ""})
+    )
+    assert spec["tabs"] == []
+    assert spec["controls"] == []


### PR DESCRIPTION
This fixes #753 

The header is removed if empty.

![grafik](https://github.com/user-attachments/assets/6a45b528-069b-4954-b07b-d65d2a961f46)
