### PR TITLE
Add option to have text-only locations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,1 @@
+docs/changelog.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -23,6 +23,7 @@ The latest version might not be released, yet.
 - Update dependencies
 - Update Russian translation by Yurt Page, Ukrainian by Максим Горпиніч, German by Nicco Kunzmann, Finnish by Ricky Tigg, Tamil by [தமிழ்நேரம்], Greek by Dimitris B
 - Update DHTMLX Scheduler to 7.2.3
+- Add option to disable map links for event locations, see [Issue 717](https://github.com/niccokunzmann/open-web-calendar/issues/717)
 
 ## v1.49
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -24,6 +24,7 @@ The latest version might not be released, yet.
 - Update Russian translation by Yurt Page, Ukrainian by Максим Горпиніч, German by Nicco Kunzmann, Finnish by Ricky Tigg, Tamil by [தமிழ்நேரம்], Greek by Dimitris B
 - Update DHTMLX Scheduler to 7.2.3
 - Add option to disable map links for event locations, see [Issue 717](https://github.com/niccokunzmann/open-web-calendar/issues/717)
+- Remove `event_url_name` parameter and translate "OpenStreetMap".
 
 ## v1.49
 

--- a/open_web_calendar/default_specification.yml
+++ b/open_web_calendar/default_specification.yml
@@ -177,11 +177,10 @@ javascript_url: []
 ## We use https://pypi.org/project/icalendar-compatibility/ for this.
 ## See https://icalendar-compatibility.readthedocs.io/en/latest/usage.html#custom-map-spec
 ## event_url_location needs to contain {location} and can contain {zoom}
+## If you change this option in here, you should also adjust the map links in index.js.
 event_url_location: "https://www.openstreetmap.org/search?query={location}"
 ## event_url_geo needs to contain {lon} and {lat} can contain {zoom}
-event_url_geo: "https://www.openstreetmap.org/#map=16/{lat}/{lon}"
-## The name of this URL in the user interface
-event_url_name: "OpenStreetMap"
+event_url_geo: "https://www.openstreetmap.org/#map={zoom}/{lat}/{lon}"
 
 ## Do you want the organizer to be shown below the event?
 ## See also https://www.rfc-editor.org/rfc/rfc5545.html#page-113

--- a/open_web_calendar/features/issue-23-links-to-map.feature
+++ b/open_web_calendar/features/issue-23-links-to-map.feature
@@ -1,6 +1,7 @@
 Feature: I want to customize the links to the location of an event.
 
     Scenario: Open Street Map is the default choice.
+        # If this errors, you might have changed the default_specification.yml
         Given we configure the map
          When we choose "OpenStreetMap" in "select-map"
          Then "event_url_location" is not specified

--- a/open_web_calendar/features/issue-717-choose-text-only-location.feature
+++ b/open_web_calendar/features/issue-717-choose-text-only-location.feature
@@ -1,0 +1,16 @@
+Feature: Sometimes, there is no service to look up the location of an event. So, I would like to choose that there is only text for the location.
+
+    Scenario: When the map link templates are empty, the link does nothing.
+        Given we add the calendar "issue-23-location-berlin"
+          And we set the "event_url_location" parameter to ""
+          And we set the "event_url_geo" parameter to ""
+         When we look at 2025-01-10
+          And we click on the event "Event in Berlin!"
+         Then the link "Berlin" opens ""
+
+    Scenario: When I configure the calendar, I would like to disable links to a map.
+        Given we configure the map
+         When we choose "Text Without Link" in "select-map"
+         Then "event_url_location" is specified as ""
+         Then "event_url_geo" is specified as ""
+

--- a/open_web_calendar/features/steps/browser_steps.py
+++ b/open_web_calendar/features/steps/browser_steps.py
@@ -626,7 +626,8 @@ def step_impl(context, link_text, link_target):
 
 
 @then('the link "{link_text}" opens "{link_href}"')
-def step_impl(context, link_text, link_href):
+@then('the link "{link_text}" opens ""')
+def step_impl(context, link_text, link_href=""):
     """Check the href of a link."""
     assert_tag_with_text_attribute_equals(context, "a", link_text, "href", link_href)
 

--- a/open_web_calendar/static/js/index.js
+++ b/open_web_calendar/static/js/index.js
@@ -132,27 +132,39 @@ function setSpecificationValueFromId(specification, key, id) {
 
 
 /* Create a mapping for the map.
- *
+ * If you add something here, also add it to the options in the index.html template.
+ * Berlin, the capital city of Germany, has a latitude of 52.520008 and a longitude of 13.404954.
+ * OpenStreetMap is the default, so make sure this is the same value as in the default_specification.yml.
  */
 
 function getMapOptions() {
     return {
-        "default" : {
-            "location": configuration.default_specification.event_url_location,
-            "geo": configuration.default_specification.event_url_geo,
+        "osm" : {
+            // configuration.default_specification.event_url_location,
+            "location": "https://www.openstreetmap.org/search?query={location}",
+            // configuration.default_specification.event_url_geo,
+            "geo": "https://www.openstreetmap.org/#map={zoom}/{lat}/{lon}",
         },
-        "Google Maps" : {
+        "google" : {
             "location": "https://www.google.com/maps/search/{location}",
             "geo": "https://www.google.com/maps/@{lat},{lon},{zoom}z",
         },
-        "Bing Maps" : {
+        "bing" : {
             "location": "https://www.bing.com/maps?q={location}&lvl={zoom}",
             "geo": "https://www.bing.com/maps?brdr=1&cp={lat}%7E{lon}&lvl={zoom}",
         },
-        "geo:" : {
+        "geo" : {
             "location": "",
             "geo": "geo:{lat},{lon}",
-        }
+        },
+        "none" : {
+            "location": "",
+            "geo": "",
+        },
+        "yandex" : {
+            "location": "https://yandex.com/maps?text={location}",
+            "geo": "https://yandex.com/maps/?ll={lon}%2C{lat}&z={zoom}",
+        },
     }
 }
 
@@ -372,15 +384,8 @@ function fillMapInputs() {
     const options = getMapOptions();
     var optionChosen = false;
     getOwnProperties(options).forEach(function (optionId) {
-        if (optionId != "default") {
-            /* Create an option */
-            var option = document.createElement("option");
-            option.value = optionId;
-            option.text = optionId;
-            mapInputs.appendChild(option);
-        }
         /* select an option */
-        var option = options[optionId];
+        const option = options[optionId];
         if (option.geo == specification.event_url_geo && option.location == specification.event_url_location) {
             mapInputs.value = optionId;
             optionChosen = true;
@@ -389,8 +394,6 @@ function fillMapInputs() {
     if (!optionChosen) {
         mapInputs.value = "";
     }
-    var defaultOption = document.getElementById("map-option-default");
-    defaultOption.text = configuration.default_specification.event_url_name;
     mapInputs.appendChild(lastChild);
     const inputGeo = document.getElementById("map-link-geo");
     inputGeo.value = specification.event_url_geo;

--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -219,7 +219,12 @@ SPDX-License-Identifier: GPL-2.0-only
                 </p>
                 <p class="action-paragraph">
                     <select id="select-map">
-                        <option value="default" id="map-option-default"></option>
+                        <option value="osm">{{ string("map-osm") }}</option>
+                        <option value="none">{{ string("map-none") }}</option>
+                        <option value="bing">{{ string("map-bing") }}</option>
+                        <option value="google">{{ string("map-google") }}</option>
+                        <option value="yandex">{{ string("map-yandex") }}</option>
+                        <option value="geo">{{ string("map-geo") }}</option>
                         <option value="" id="map-option-custom">{{ string("map-custom") }}</option>
                     </select>
                 </p>

--- a/open_web_calendar/test/test_specification.py
+++ b/open_web_calendar/test/test_specification.py
@@ -85,9 +85,8 @@ def test_boolean_values_of_parameters():
     assert spec["clean_html_style"] is False
     assert spec["clean_html_links"] is True
 
+
 def test_empty_array():
-    spec = get_specification(
-        query=MultiDict({"tabs": "", "controls": ""})
-    )
+    spec = get_specification(query=MultiDict({"tabs": "", "controls": ""}))
     assert spec["tabs"] == []
     assert spec["controls"] == []

--- a/open_web_calendar/translations/en/index.yml
+++ b/open_web_calendar/translations/en/index.yml
@@ -177,6 +177,13 @@ map-custom-summary: "Customize the map links"
 map-link-location-description: "Enter the URL to the map here and insert {location} where the search query goes."
 # Describe customization
 map-link-geo-description: "Enter the URL to the map here and insert {lat} and {lon} for the coordinates."
+# Specific map names
+map-osm: "OpenStreetMap"
+map-bing: "Bing Maps"
+map-google: "Google Maps"
+map-yandex: "Yandex Maps"
+map-geo: "geo: Link"
+map-none: "Text Without Link"
 
 
 # Heading of option


### PR DESCRIPTION
This fixes #717 

- add text-only location
- fix that if default is changed, OSM stays working
- remove event_url_name parameter
- add Yandex maps