### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -5,6 +5,9 @@
 # up-to-date.
 name: "Update Repository"
 
+permissions:
+  contents: write
+
 on: [push]
 
 # cancel builds in progress if a new push has been made to the same ref


### PR DESCRIPTION
Potential fix for [https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/27](https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/27)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's tasks, the following permissions are needed:
- `contents: write` for pushing updates to translation files.
- `pull-requests: write` if the workflow interacts with pull requests (though this is not evident in the current code).

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`update-translation-po-files`) to limit its scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
