### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -240,6 +240,8 @@ jobs:
       - dockerhub
       - deploy-tag-to-pypi
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: create release


### PR DESCRIPTION
Potential fix for [https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/34](https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/34)

To fix the issue, we need to add a `permissions` block to the `github-release` job to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the job involves publishing a GitHub release, it likely requires `contents: read` and `contents: write` permissions. These permissions allow the job to read repository contents and create or update releases.

The fix involves:
1. Adding a `permissions` block under the `github-release` job.
2. Setting the permissions to the least privilege required for the job, which is `contents: read` and `contents: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
