### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -176,6 +176,8 @@ jobs:
     needs:
     - run-tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # This environment stores the TWINE_USERNAME and TWINE_PASSWORD
     # see https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
     environment:


### PR DESCRIPTION
Potential fix for [https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/33](https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/33)

To fix the issue, we will add a `permissions` block to the `deploy-tag-to-pypi` job. This block will explicitly define the minimal permissions required for the job to function. Since the job involves publishing a package to PyPI, it does not need write access to the repository contents. Therefore, we will set `contents: read` as the permission. This change will ensure that the job has only the necessary access, improving security.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
