### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -111,6 +111,8 @@ jobs:
     name: Publish Docker Image on Docker Hub
     runs-on: ubuntu-latest
     if: ${{ github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/v') }}
+    permissions:
+      contents: read
     # This environment stores the DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
     # see https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
     environment:


### PR DESCRIPTION
Potential fix for [https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/32](https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/32)

To fix the issue, we will add a `permissions` block to the `dockerhub` job. This block will explicitly define the minimal permissions required for the job to function. Since the job involves publishing a Docker image, it likely only needs `contents: read` to access the repository's contents. We will add this permissions block directly under the `dockerhub` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
