### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -87,6 +87,8 @@ jobs:
   link-check:
     name: "Check Links in Documentation"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: ${{ ! startsWith(github.ref, 'refs/tags/v')}}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/31](https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/31)

To fix the issue, we will add a `permissions` block to the `link-check` job. This block will explicitly set the permissions for the `GITHUB_TOKEN` to the minimum required for the job. Since the job only needs to read repository contents, we will set `contents: read`. This change ensures that the job cannot perform any unintended write operations.

The `permissions` block will be added directly under the `link-check` job definition, ensuring it applies only to this job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
