### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -70,6 +70,8 @@ jobs:
     name: "Publish Documentation to GitHub Pages"
     runs-on: ubuntu-latest
     if: ${{ github.ref_name == 'master' }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/30](https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/30)

To fix the issue, we need to add a `permissions` block to the "Publish Documentation to GitHub Pages" job. This block should specify the minimal permissions required for the job to function correctly. Since the job involves publishing documentation, it likely requires `contents: write` permission to push changes to the `gh-pages` branch. Other permissions should be set to `read` or omitted if not needed.

The `permissions` block will be added under the `gh-pages` job definition in the `.github/workflows/run-tests.yml` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
