### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 name: Ruff
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   ruff:


### PR DESCRIPTION
Potential fix for [https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/29](https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/29)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the least privileges required for the workflow. Since the workflow appears to involve running Ruff (a linter) and does not seem to require write access, we will set `contents: read` as the permission. This ensures the workflow can read the repository contents but cannot make any modifications.

The changes will be made at the root level of the workflow file, immediately after the `name` field, to apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
