### PR TITLE
Potential fix for code scanning alert no. 28: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,8 @@ jobs:
   run-tests:
     name: "Build & Run Tests"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         # deprecate python versions also in
@@ -69,6 +71,8 @@ jobs:
   gh-pages:
     name: "Publish Documentation to GitHub Pages"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: ${{ github.ref_name == 'master' }}
     steps:
       - uses: actions/checkout@v4
@@ -172,6 +176,8 @@ jobs:
   deploy-tag-to-pypi:
     name: Publish Package on PyPI
     # only deploy on tags, see https://stackoverflow.com/a/58478262/1320237
+    permissions:
+      contents: read
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     needs:
     - run-tests


### PR DESCRIPTION
Potential fix for [https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/28](https://github.com/niccokunzmann/open-web-calendar/security/code-scanning/28)

To address the issue, we will add a `permissions` block to the workflow. This block will explicitly define the permissions required for each job, ensuring that the `GITHUB_TOKEN` has the least privilege necessary to complete the tasks. For the `run-tests` job, we will set `contents: read`, as it primarily involves running tests and uploading artifacts, which do not require write access. For other jobs, such as `gh-pages` and `deploy-tag-to-pypi`, we will analyze their requirements and set appropriate permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
