### PR TITLE
Docs: remove broken Polar funding link (fixes #948)

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -18,7 +18,6 @@ description: "You can improve the project yourself. Get started here."
 There are several ways in which you can help this project:
 
 - [Use it]({{link.web}}) and [report errors]({{link.issues}})
-- [Fund development & maintenance - Polar]({{link.fund.polar}})
 - [Fund costs - Open Collective]({{link.fund.open_collective}})
 - [Fund sustainability - GitHub Sponsors]({{link.fund.github_sponsors}})
 - [Translate this project to your language](../dev/translate)


### PR DESCRIPTION
This pull request removes the broken Polar funding link from the contributing documentation, as reported in issue #948.