### PR TITLE
Open files with explicit utf-8 encoding

### DIFF
--- a/open_web_calendar/test/conftest.py
+++ b/open_web_calendar/test/conftest.py
@@ -110,7 +110,7 @@ def runner(app):
 calendar_files = {}
 for file in CALENDAR_DIRECTORY.iterdir():
     if file.is_file():
-        with file.open() as f:
+        with file.open(encoding="utf-8") as f:
             calendar_files[file] = f.read()
 
 

--- a/open_web_calendar/translate.py
+++ b/open_web_calendar/translate.py
@@ -47,7 +47,7 @@ for language in os.listdir(TRANSLATIONS_PATH):  # noqa: PTH208, RUF100
             continue
         name = file.stem
         name = name.removesuffix(UNUSED)
-        with file.open() as f:
+        with file.open(encoding="utf-8") as f:
             file_translations[name].update(yaml.safe_load(f))
 
 


### PR DESCRIPTION
Fixes #1127.

See #1117.

On Windows, Python's default file encoding is cp1252, causing `UnicodeDecodeError` when reading UTF-8 translation and calendar files.