### PR TITLE
Proxy javascript_url through OWC to enforce JS content type

### DIFF
--- a/open_web_calendar/app.py
+++ b/open_web_calendar/app.py
@@ -358,6 +358,16 @@ def serve_locale(lang):
     )
 
 
+@app.route("/js/proxy")
+@allowed_hosts.limit()
+def serve_js_proxy():
+    """Proxy a remote script and re-serve it as text/javascript."""
+    url = request.args.get("url")
+    if not url:
+        return "Missing url parameter", 400
+    return make_js_file_response(get_text_from_url(url).decode("utf-8"))
+
+
 @app.errorhandler(500)
 def unhandled_exception(error):
     """Called when an error occurs.

--- a/open_web_calendar/templates/calendars/dhtmlx.html
+++ b/open_web_calendar/templates/calendars/dhtmlx.html
@@ -50,7 +50,7 @@ SPDX-License-Identifier: GPL-2.0-only
             {{ specification['css'] | safe }}
         </style>
         {% for link in specification.javascript_url %}
-        <script src="{{ link }}" charset="utf-8"></script>
+        <script src="/js/proxy?url={{ link | urlencode }}" charset="utf-8"></script>
         {% endfor %}
         <script type="text/javascript">
             function onCalendarInitialized() {

--- a/open_web_calendar/templates/calendars/dhtmlx.html
+++ b/open_web_calendar/templates/calendars/dhtmlx.html
@@ -50,7 +50,11 @@ SPDX-License-Identifier: GPL-2.0-only
             {{ specification['css'] | safe }}
         </style>
         {% for link in specification.javascript_url %}
+        {% if link.startswith("http://") or link.startswith("https://") %}
         <script src="/js/proxy?url={{ link | urlencode }}" charset="utf-8"></script>
+        {% else %}
+        <script src="{{ link }}" charset="utf-8"></script>
+        {% endif %}
         {% endfor %}
         <script type="text/javascript">
             function onCalendarInitialized() {

--- a/open_web_calendar/test/test_issue_633_javascript_url_content_type.py
+++ b/open_web_calendar/test/test_issue_633_javascript_url_content_type.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+"""Make sure javascript_url scripts execute even when the remote server
+returns a non-JavaScript Content-Type (e.g. text/plain from a GitHub gist).
+
+See https://github.com/niccokunzmann/open-web-calendar/issues/633
+"""
+
+import re
+
+
+def test_javascript_url_is_served_with_javascript_content_type(client, cache_url):
+    """A remote script served as text/plain must reach the browser as
+    text/javascript so nosniff browsers will execute it."""
+    js_url = "http://example.com/script.js"
+    js_content = "console.log('hi from a gist');"
+    cache_url(js_url, js_content)
+
+    page = client.get(f"/calendar.html?javascript_url={js_url}").text
+    sources = re.findall(r'<script\s+src="([^"]+)"', page)
+
+    served_contents = []
+    for src in sources:
+        if src.startswith(("http://", "https://")):
+            continue  # remote scripts must not be referenced directly
+        response = client.get(src)
+        if response.headers.get("Content-Type", "").startswith("text/javascript"):
+            served_contents.append(response.data.decode("utf-8"))
+
+    assert any(js_content in body for body in served_contents)

--- a/open_web_calendar/test/test_issue_633_javascript_url_content_type.py
+++ b/open_web_calendar/test/test_issue_633_javascript_url_content_type.py
@@ -25,11 +25,11 @@ def test_javascript_url_is_served_with_javascript_content_type(client, cache_url
         f"remote script src must be proxied, got: {sources}"
     )
 
-    js_responses = [client.get(src) for src in sources]
-    js_bodies = [
-        r.data.decode("utf-8")
-        for r in js_responses
-        if r.headers.get("Content-Type", "").startswith("text/javascript")
-    ]
-
-    assert any(js_content in body for body in js_bodies)
+    served_as_js = False
+    for src in sources:
+        r = client.get(src)
+        is_js = r.headers.get("Content-Type", "").startswith("text/javascript")
+        if is_js and js_content in r.data.decode("utf-8"):
+            served_as_js = True
+            break
+    assert served_as_js, f"no script source served {js_content!r} as text/javascript"

--- a/open_web_calendar/test/test_issue_633_javascript_url_content_type.py
+++ b/open_web_calendar/test/test_issue_633_javascript_url_content_type.py
@@ -21,12 +21,15 @@ def test_javascript_url_is_served_with_javascript_content_type(client, cache_url
     page = client.get(f"/calendar.html?javascript_url={js_url}").text
     sources = re.findall(r'<script\s+src="([^"]+)"', page)
 
-    served_contents = []
-    for src in sources:
-        if src.startswith(("http://", "https://")):
-            continue  # remote scripts must not be referenced directly
-        response = client.get(src)
-        if response.headers.get("Content-Type", "").startswith("text/javascript"):
-            served_contents.append(response.data.decode("utf-8"))
+    assert not any(src.startswith(("http://", "https://")) for src in sources), (
+        f"remote script src must be proxied, got: {sources}"
+    )
 
-    assert any(js_content in body for body in served_contents)
+    js_responses = [client.get(src) for src in sources]
+    js_bodies = [
+        r.data.decode("utf-8")
+        for r in js_responses
+        if r.headers.get("Content-Type", "").startswith("text/javascript")
+    ]
+
+    assert any(js_content in body for body in js_bodies)

--- a/open_web_calendar/test/test_issue_71_add_javascript.py
+++ b/open_web_calendar/test/test_issue_71_add_javascript.py
@@ -17,11 +17,14 @@ import pytest
     [
         (
             "?javascript_url=https://tippi.js/embed.js",
-            ['<script src="https://tippi.js/embed.js"'],
+            ['<script src="/js/proxy?url=https%3A//tippi.js/embed.js"'],
         ),
         (
             "?javascript_url=/feature1.js&javascript_url=/feature2.js",
-            ['<script src="/feature1.js"', '<script src="/feature2.js"'],
+            [
+                '<script src="/js/proxy?url=/feature1.js"',
+                '<script src="/js/proxy?url=/feature2.js"',
+            ],
         ),
     ],
 )

--- a/open_web_calendar/test/test_issue_71_add_javascript.py
+++ b/open_web_calendar/test/test_issue_71_add_javascript.py
@@ -21,10 +21,7 @@ import pytest
         ),
         (
             "?javascript_url=/feature1.js&javascript_url=/feature2.js",
-            [
-                '<script src="/js/proxy?url=/feature1.js"',
-                '<script src="/js/proxy?url=/feature2.js"',
-            ],
+            ['<script src="/feature1.js"', '<script src="/feature2.js"'],
         ),
     ],
 )


### PR DESCRIPTION
Fixes #633.

Remote `javascript_url` entries route through a new `/js/proxy` endpoint that re-serves them with `Content-Type: text/javascript`, so gist URLs and other sources that serve JS as `text/plain` execute regardless of the remote `X-Content-Type-Options: nosniff`. Relative paths keep their existing direct-src behaviour.