### PR TITLE
Deduplicate error messages while logging every occurrence

### DIFF
--- a/open_web_calendar/convert/base.py
+++ b/open_web_calendar/convert/base.py
@@ -68,13 +68,13 @@ class ConversionStrategy:
             if key in self.seen_errors:
                 return None
             self.seen_errors.add(key)
-        tb_s = io.StringIO()
-        traceback.print_exception(ty, err, tb, file=tb_s)
-        return self.convert_error(
-            error_str,
-            url,
-            tb_s.getvalue() if self.debug else "",
-        )
+            tb_s = io.StringIO()
+            traceback.print_exception(ty, err, tb, file=tb_s)
+            return self.convert_error(
+                error_str,
+                url,
+                tb_s.getvalue() if self.debug else "",
+            )
 
     def convert_error(self, error: str, url: str, tb_s: str):
         """Tell the client more about the error."""

--- a/open_web_calendar/convert/base.py
+++ b/open_web_calendar/convert/base.py
@@ -35,7 +35,7 @@ def get_text_from_url(url):
 class ConversionStrategy:
     """Base class for conversions.
 
-    You can customize how calendars are retrived and if encryption is used.
+    You can customize how calendars are retrieved and if encryption is used.
     """
 
     # TODO: add as parameters
@@ -52,6 +52,7 @@ class ConversionStrategy:
         self.encryption = EmptyFernetStore() if encryption is None else encryption
         self.lock = RLock()
         self.components = []
+        self.seen_errors: set[tuple[str, str]] = set()
         self.get_text_from_url = get_text_from_url
         self.debug = debug
         self.created()
@@ -60,10 +61,17 @@ class ConversionStrategy:
         """Template method for subclasses."""
 
     def error(self, ty, err, tb, url):
+        traceback.print_exception(ty, err, tb)
+        error_str = str(err) if self.debug else type(err).__name__
+        key = (error_str, url)
+        with self.lock:
+            if key in self.seen_errors:
+                return None
+            self.seen_errors.add(key)
         tb_s = io.StringIO()
         traceback.print_exception(ty, err, tb, file=tb_s)
         return self.convert_error(
-            str(err) if self.debug else type(err).__name__,
+            error_str,
             url,
             tb_s.getvalue() if self.debug else "",
         )
@@ -86,7 +94,7 @@ class ConversionStrategy:
                 pass  # no error should pass silently; import this
 
     def get_calendars_from_url(self, url: str) -> Calendars:
-        """Return a lis of calendars from a URL."""
+        """Return a list of calendars from a URL."""
         if self.encryption.is_encrypted(url):
             url = self.encryption.decrypt(url).url
             if url is None:
@@ -126,10 +134,12 @@ class ConversionStrategy:
         except:
             ty, err, tb = sys.exc_info()
             with self.lock:
-                self.components.append(self.error(ty, err, tb, url))
+                component = self.error(ty, err, tb, url)
+                if component is not None:
+                    self.components.append(component)
 
     def collect_components_from(self, index: int, calendars: Calendars):
-        """Collect all the compenents from the calendar."""
+        """Collect all the components from the calendar."""
         raise NotImplementedError("to be implemented in subclasses")
 
     def merge(self):

--- a/open_web_calendar/convert/base.py
+++ b/open_web_calendar/convert/base.py
@@ -133,9 +133,9 @@ class ConversionStrategy:
             self.collect_components_from(index, calendars)
         except:
             ty, err, tb = sys.exc_info()
-            with self.lock:
-                component = self.error(ty, err, tb, url)
-                if component is not None:
+            component = self.error(ty, err, tb, url)
+            if component is not None:
+                with self.lock:
                     self.components.append(component)
 
     def collect_components_from(self, index: int, calendars: Calendars):

--- a/open_web_calendar/test/test_issue_777_error_deduplication.py
+++ b/open_web_calendar/test/test_issue_777_error_deduplication.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+"""Errors are deduplicated in user output but always logged.
+
+See https://github.com/niccokunzmann/open-web-calendar/issues/777
+"""
+
+import pytest
+
+from open_web_calendar.convert.calendar import ConvertToCalendars
+from open_web_calendar.convert.events import ConvertToEvents
+from open_web_calendar.convert.ics import ConvertToICS
+
+
+def boom(url):
+    raise ValueError("nope")
+
+
+def get_errors(strategy):
+    if isinstance(strategy, ConvertToCalendars):
+        return strategy.errors
+    if isinstance(strategy, ConvertToEvents):
+        return [c for c in strategy.components if c.get("type") == "error"]
+    return [
+        c
+        for c in strategy.components
+        if any(str(e.get("UID", "")).startswith("error") for e in c.walk("VEVENT"))
+    ]
+
+
+@pytest.fixture(params=[ConvertToCalendars, ConvertToEvents, ConvertToICS])
+def strategy_cls(request):
+    return request.param
+
+
+SPEC = {
+    "url": [],
+    "title": "t",
+    "source_code": "x",
+    "timezone": "UTC",
+    "timeshift": 0,
+}
+
+
+def test_same_url_failing_twice_records_one_error(strategy_cls, capfd):
+    spec = SPEC | {"url": ["http://x.example/a", "http://x.example/a"]}
+    strategy = strategy_cls(spec, get_text_from_url=boom)
+    strategy.retrieve_calendars()
+    assert len(get_errors(strategy)) == 1
+    assert capfd.readouterr().err.count("ValueError") >= 2
+
+
+def test_two_urls_failing_identically_record_two_errors(strategy_cls):
+    spec = SPEC | {"url": ["http://a.example/x", "http://b.example/y"]}
+    strategy = strategy_cls(spec, get_text_from_url=boom)
+    strategy.retrieve_calendars()
+    assert len(get_errors(strategy)) == 2


### PR DESCRIPTION
Fixes #777.

Errors from calendar sources are deduplicated by (error type, URL) in the user-facing output. Each occurrence is still logged to stderr so admins see the true failure rate.