### PR TITLE
Skip traceback formatting in production mode

### DIFF
--- a/open_web_calendar/convert/base.py
+++ b/open_web_calendar/convert/base.py
@@ -68,13 +68,12 @@ class ConversionStrategy:
             if key in self.seen_errors:
                 return None
             self.seen_errors.add(key)
-            tb_s = io.StringIO()
-            traceback.print_exception(ty, err, tb, file=tb_s)
-            return self.convert_error(
-                error_str,
-                url,
-                tb_s.getvalue() if self.debug else "",
-            )
+            tb_s = ""
+            if self.debug:
+                sio = io.StringIO()
+                traceback.print_exception(ty, err, tb, file=sio)
+                tb_s = sio.getvalue()
+            return self.convert_error(error_str, url, tb_s)
 
     def convert_error(self, error: str, url: str, tb_s: str):
         """Tell the client more about the error."""


### PR DESCRIPTION
Fixes #1183.

Avoid allocating a StringIO and formatting the full traceback when `self.debug` is False, since the result is discarded anyway.