### PR TITLE
Stop 500 when timezone query parameter appears twice

### DIFF
--- a/open_web_calendar/app.py
+++ b/open_web_calendar/app.py
@@ -218,8 +218,8 @@ def get_specification(query=None):
         if isinstance(specification.get(parameter), list):
             if len(value) == 1 and value[0] == "":
                 value = []
-        elif len(value) == 1:
-            value = value[0]
+        else:
+            value = value[-1]
         specification[parameter] = value
 
     specification.pop(PARAM_SPECIFICATION_URL, None)
@@ -377,7 +377,7 @@ def unhandled_exception(error):
     trace = (
         f"<pre>\r\n{traceback.format_exc()}</pre>"
         if config.debug
-        else "Trace only avalilable if DEBUG=true."
+        else "Trace only available if DEBUG=true."
     )
     return (
         f"""

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -544,8 +544,10 @@ function loadScheduler() {
     scheduler.clearAll();
     let schedulerUrl = document.location.pathname.replace(/.html$/, ".events.json") + document.location.search;
     // add the time zone if not specified
-    if (specification.timezone == "" && !/[?&]timezone=/.test(schedulerUrl)) {
-        schedulerUrl += (document.location.search ? "&" : "?") + "timezone=" + getTimezone();
+    if (specification.timezone == "") {
+        const params = new URLSearchParams(document.location.search);
+        params.set("timezone", getTimezone());
+        schedulerUrl = document.location.pathname.replace(/.html$/, ".events.json") + "?" + params.toString();
     }
 
     scheduler.load(schedulerUrl, "json");

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -64,7 +64,7 @@ function makeLink(url, html) {
 
 
 /*
- * Download the vent ICS with a file name.
+ * Download the event ICS with a file name.
  */
 function downloadICS(event) {
     // from https://stackoverflow.com/a/18197341/1320237
@@ -544,7 +544,7 @@ function loadScheduler() {
     scheduler.clearAll();
     let schedulerUrl = document.location.pathname.replace(/.html$/, ".events.json") + document.location.search;
     // add the time zone if not specified
-    if (specification.timezone == "") {
+    if (specification.timezone == "" && !/[?&]timezone=/.test(schedulerUrl)) {
         schedulerUrl += (document.location.search ? "&" : "?") + "timezone=" + getTimezone();
     }
 

--- a/open_web_calendar/test/test_specification.py
+++ b/open_web_calendar/test/test_specification.py
@@ -98,3 +98,14 @@ def test_specification_url_is_not_in_resulting_spec(url, cache_url):
     cache_url(url, '{"css": "123"}')
     spec = get_specification(query=MultiDict({"specification_url": url}))
     assert "specification_url" not in spec
+
+
+def test_duplicate_timezone_takes_last_value():
+    """A scalar spec key keeps a scalar value when the query duplicates it.
+
+    See https://github.com/niccokunzmann/open-web-calendar/issues/320
+    """
+    spec = get_specification(
+        query=MultiDict([("timezone", ""), ("timezone", "Asia/Kolkata")])
+    )
+    assert spec["timezone"] == "Asia/Kolkata"


### PR DESCRIPTION
Fixes #320.

A trailing `timezone=` made the JS append a second `timezone=`, and the server resolved that to a list which `ZoneInfo` couldn't handle. The JS now uses `URLSearchParams.set` to inject the browser timezone (replacing any stale value instead of appending), and `get_specification` picks the last value for scalar spec keys with duplicates.