### PR TITLE
Sanitize X-ALT-DESC HTML in ICS output

### DIFF
--- a/open_web_calendar/convert/ics.py
+++ b/open_web_calendar/convert/ics.py
@@ -4,6 +4,7 @@
 """Convert the source links according to the specification to an ICS file."""
 
 import datetime
+import re
 
 from flask import Response
 from icalendar import Calendar, Event, Timezone
@@ -20,6 +21,13 @@ from .base import ConversionStrategy
 class ConvertToICS(ConversionStrategy):
     """Convert events to ICS. This conforms to a strategy pattern."""
 
+    html_description_property = "X-ALT-DESC"
+
+    def clean_ics_html(self, html: str) -> str:
+        """Clean and compact HTML before storing it in an ICS property."""
+        cleaned_html = " ".join(self.clean_html(html).split())
+        return re.sub(r">\s+<", "><", cleaned_html)
+
     def created(self):
         self.title = self.specification["title"]
         self.timezones = set()  # ids
@@ -35,6 +43,25 @@ class ConvertToICS(ConversionStrategy):
     def collect_components_from(self, calendar_index: int, calendars: Calendars):
         with self.lock:
             self.components.extend(calendars.get_icalendars())
+
+    def clean_html_descriptions(self, calendar: Calendar):
+        """Clean HTML descriptions before serializing the ICS response."""
+        for event in calendar.walk("VEVENT"):
+            description = event.get(self.html_description_property)
+            if description is None:
+                continue
+            descriptions = (
+                description if isinstance(description, list) else [description]
+            )
+            cleaned_descriptions = []
+            for value in descriptions:
+                parameters = value.params.copy() if hasattr(value, "params") else {}
+                cleaned_descriptions.append(
+                    (self.clean_ics_html(str(value)), parameters)
+                )
+            del event[self.html_description_property]
+            for value, parameters in cleaned_descriptions:
+                event.add(self.html_description_property, value, parameters=parameters)
 
     def convert_error(self, error: str, url: str, tb_s: str):
         """Create an error event that appears in the ICS output."""
@@ -74,6 +101,7 @@ class ConvertToICS(ConversionStrategy):
                 event["DESCRIPTION"] = description.text or remove_html(html)
                 if "X-ALT-DESC" not in event:
                     event.add("X-ALT-DESC", html, parameters={"FMTTYPE": "text/html"})
+        self.clean_html_descriptions(calendar)
         return Response(calendar.to_ical(), mimetype="text/calendar")
 
 

--- a/open_web_calendar/features/downloads/2024-03-22 Head Start Menu (ages 3-5).ics
+++ b/open_web_calendar/features/downloads/2024-03-22 Head Start Menu (ages 3-5).ics
@@ -16,13 +16,10 @@ RECURRENCE-ID;VALUE=DATE:20240322
 DESCRIPTION:Breakfast\n\nHoneydew\n\nCinnamon Bread\n\n1% Milk\n\nLunch\n\
  nGround Beef Stroganoff\n\nSteamed Cauliflower\n\nApricots\n\n1% Milk\n\nS
  nack\n\nBroccoli\n\nBread Sticks\n\nCottage Cheese\n\n1% Milk
-X-ALT-DESC;FMTTYPE=text/html:<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//
- EN"><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http:/
- /www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www
- .w3.org/1999/xhtml"><head><title></title></head><body><u><strong>Breakfast
- </strong></u><br />Honeydew<br />Cinnamon Bread<br />1% Milk<hr /><u><stro
- ng>Lunch</strong></u><br />Ground Beef Stroganoff<br />Steamed Cauliflower
- <br />Apricots<br />1% Milk<hr /><u><strong>Snack</strong></u><br />Brocco
- li<br />Bread Sticks<br />Cottage Cheese<br />1% Milk</body></html>
+X-ALT-DESC;FMTTYPE=text/html:<u><strong> Breakfast </strong></u><br> Honey
+ dew <br> Cinnamon Bread <br> 1% Milk <hr><u><strong> Lunch </strong></u><b
+ r> Ground Beef Stroganoff <br> Steamed Cauliflower <br> Apricots <br> 1% M
+ ilk <hr><u><strong> Snack </strong></u><br> Broccoli <br> Bread Sticks <br
+ > Cottage Cheese <br> 1% Milk
 END:VEVENT
 END:VCALENDAR

--- a/open_web_calendar/test/test_issue_167_html_in_description.py
+++ b/open_web_calendar/test/test_issue_167_html_in_description.py
@@ -11,11 +11,43 @@ clean text while X-ALT-DESC carries the HTML for clients that want it.
 See https://github.com/niccokunzmann/open-web-calendar/issues/167
 """
 
+from icalendar import Calendar, Event
 from icalendar_compatibility import Description
+
+from open_web_calendar.app import get_default_specification
+from open_web_calendar.convert.ics import ConvertToICS
 
 
 def event_by_uid(cal, uid):
     return next(e for e in cal.events if str(e.get("UID", "")) == uid)
+
+
+def merged_event(event):
+    """Return the event after serializing and parsing the ICS response."""
+    source = Calendar()
+    source.add_component(event)
+    converter = ConvertToICS(get_default_specification())
+    converter.components.append(source)
+    return Calendar.from_ical(converter.merge().data).events[0]
+
+
+def unsafe_html():
+    return (
+        '<p>safe</p><script>alert(1)</script>'
+        '<a href="javascript:alert(2)" onclick="evil()">bad</a>'
+    )
+
+
+def assert_x_alt_desc_is_cleaned(event):
+    x_alt = event["X-ALT-DESC"]
+    text = str(x_alt)
+    assert x_alt.params.get("FMTTYPE") == "text/html"
+    assert "safe" in text
+    assert "bad" in text
+    assert "<script" not in text
+    assert "javascript:" not in text
+    assert "onclick" not in text
+    assert "\n" not in text
 
 
 def test_html_in_description_is_stripped(merged):
@@ -29,8 +61,7 @@ def test_html_in_description_is_stripped(merged):
 
 
 def test_html_is_preserved_in_x_alt_desc(merged):
-    """When the source carried HTML, X-ALT-DESC must keep it so HTML-aware
-    clients still get the formatted version."""
+    """When the source carried HTML, X-ALT-DESC keeps sanitized HTML."""
     cal = merged(["issue-287-links-1"])
     events_with_html = [e for e in cal.events if e.get("X-ALT-DESC") is not None]
     assert events_with_html, "expected at least one event with X-ALT-DESC"
@@ -61,12 +92,27 @@ def test_altrep_html_is_normalised(merged):
     assert Description.this_could_be_html(str(x_alt))
 
 
-def test_existing_x_alt_desc_is_preserved(merged):
-    """When the source already has X-ALT-DESC;FMTTYPE=text/html, the HTML
-    is preserved verbatim (no overwrite)."""
-    cal = merged(["food"])
-    event = event_by_uid(cal, "2845")
-    x_alt = event["X-ALT-DESC"]
-    assert x_alt.params.get("FMTTYPE") == "text/html"
-    # Source X-ALT-DESC starts with this DOCTYPE; verify it wasn't overwritten.
-    assert str(x_alt).startswith("<!DOCTYPE HTML")
+def test_existing_x_alt_desc_is_cleaned():
+    """Source X-ALT-DESC HTML is cleaned before /calendar.ics serves it."""
+    event = Event()
+    event.add("uid", "existing-x-alt-desc")
+    event.add("summary", "Existing X-ALT-DESC")
+    event.add(
+        "x-alt-desc",
+        unsafe_html(),
+        parameters={"FMTTYPE": "text/html"},
+    )
+
+    assert_x_alt_desc_is_cleaned(merged_event(event))
+
+
+def test_promoted_description_x_alt_desc_is_cleaned():
+    """DESCRIPTION HTML promoted into X-ALT-DESC is cleaned too."""
+    event = Event()
+    event.add("uid", "promoted-x-alt-desc")
+    event.add("summary", "Promoted X-ALT-DESC")
+    event.add("description", unsafe_html())
+
+    merged = merged_event(event)
+    assert_x_alt_desc_is_cleaned(merged)
+    assert "<script" not in str(merged["DESCRIPTION"])


### PR DESCRIPTION
## Summary
- sanitize every VEVENT X-ALT-DESC value before serving `/calendar.ics`, while preserving parameters such as `FMTTYPE=text/html`
- compact sanitized ICS HTML so download fixtures stay stable and avoid pretty-print whitespace churn
- run the sanitizer after the existing DESCRIPTION normalization so both source-provided and promoted X-ALT-DESC HTML are cleaned
- add regression coverage for unsafe script, javascript: URL, and inline handler content

Fixes #1187.

## Duplicate check
- `gh pr list --repo niccokunzmann/open-web-calendar --base main --state all --search "1187 X-ALT-DESC sanitize"` returned no PRs
- `gh pr list --repo niccokunzmann/open-web-calendar --base main --state all --search "X-ALT-DESC"` only found merged #1185, which intentionally preserved X-ALT-DESC verbatim and is the adjacent prerequisite this builds on

## Tests
- `.venv/bin/python -m pytest open_web_calendar/test/test_issue_167_html_in_description.py open_web_calendar/test/test_issue_466_merge_calendars_into_ics.py -q`
- `.venv/bin/python -m ruff check open_web_calendar/convert/ics.py open_web_calendar/test/test_issue_167_html_in_description.py open_web_calendar/test/test_issue_466_merge_calendars_into_ics.py`
- `git diff --check`
- `python3` fork-mode Behave run for `features/issue-206-subscribe-to-ics.feature:3`
- generated-vs-fixture splitline check for `open_web_calendar/features/downloads/2024-03-22 Head Start Menu (ages 3-5).ics`