### PR TITLE
Remove duplicate URL assignment in ICS error events

### DIFF
--- a/open_web_calendar/convert/ics.py
+++ b/open_web_calendar/convert/ics.py
@@ -44,8 +44,6 @@ class ConvertToICS(ConversionStrategy):
         event["DESCRIPTION"] = tb_s
         event["URL"] = url
         event["UID"] = "error" + str(id(error))
-        if url:
-            event["URL"] = url
         calendar = Calendar()
         calendar.add_component(event)
         return calendar


### PR DESCRIPTION
## Summary
- remove the dead conditional `event["URL"] = url` assignment in `ConvertToICS.convert_error`
- leave behavior unchanged because `URL` is already assigned immediately before `UID`

Addresses #1186.

## Duplicate check
- `gh pr list --repo niccokunzmann/open-web-calendar --state all --search "1186 Dead code patterns clean"` returned no PRs
- `gh pr list --repo niccokunzmann/open-web-calendar --state all --search "event URL url convert_error duplicate"` only found merged #1182, which is unrelated error-message deduplication

## Tests
- `.venv/bin/python -m pytest open_web_calendar/test/test_issue_466_merge_calendars_into_ics.py -q`
- `.venv/bin/ruff check open_web_calendar/convert/ics.py`
- `git diff --check`