### PR TITLE
Document contribution workflow testing

### DIFF
--- a/docs/dev/behave.md
+++ b/docs/dev/behave.md
@@ -1,0 +1,84 @@
+---
+# SPDX-FileCopyrightText: 2026 Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+comments: true
+description: "Write and run Behave browser tests for the Open Web Calendar."
+---
+
+# Behave Tests
+
+The browser tests use [Behave](https://behave.readthedocs.io/) with Selenium.
+They exercise the built Open Web Calendar in a real browser and live in
+`open_web_calendar/features/`.
+
+## Feature Files
+
+Each `*.feature` file describes one user-facing behavior with Gherkin steps.
+Prefer adding scenarios near related behavior, for example:
+
+- `configure-the-calendar.feature` for configuration parameters.
+- `edit-the-calendar.feature` for the configuration UI.
+- Issue-specific files such as `issue-206-subscribe-to-ics.feature` for
+  regressions.
+
+The shared step implementations live in
+`open_web_calendar/features/steps/browser_steps.py`. Reuse existing steps before
+adding new ones, because many common actions are already available: adding a
+calendar fixture, setting specification parameters, opening a date, clicking
+links or buttons, checking text, checking links, downloading `.ics` files, and
+loading API recordings.
+
+## Calendar Fixtures
+
+Calendar input files live in `open_web_calendar/features/calendars/`. Put small
+`.ics` fixtures there when a scenario needs stable calendar data. Refer to a
+fixture with:
+
+```gherkin
+Given we add the calendar "one-event"
+```
+
+The step appends `.ics` when the fixture name has no extension. Download
+expectations created by tests are stored under
+`open_web_calendar/features/downloads_by_tests/` and can be compared with the
+checked fixtures in `open_web_calendar/features/downloads/`.
+
+## Running Tests
+
+Run all browser features with:
+
+```sh
+tox -e web
+```
+
+Run one feature file while iterating:
+
+```sh
+tox -e web -- open_web_calendar/features/issue-206-subscribe-to-ics.feature
+```
+
+Run a specific scenario by line number:
+
+```sh
+tox -e web -- open_web_calendar/features/configure-the-calendar.feature:42
+```
+
+Use a specific browser or window size with Behave `-D` options:
+
+```sh
+tox -e web -- -D browser=firefox
+tox -e web -- -D browser=chrome
+tox -e web -- -D window=375x812
+```
+
+When a step fails, the test environment records a screenshot in `screenshots/`
+and prints the path together with captured server output.
+
+## Adding Steps
+
+Only add a new Python step when a scenario cannot be expressed with the shared
+steps. Keep new steps small and user-focused, and put browser-specific logic in
+`browser_steps.py` so future feature files can reuse it.
+

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -88,8 +88,16 @@ tox -e web -- -D window=375x812 # iPhone11 size
 In case the browser tests fail, screenshots are recorded and a link is printed.
 
 ```sh
-
+tox -e dev
 ```
+
+The debug environment starts the test server with `APP_DEBUG=true` and uses the
+test specification from `open_web_calendar/features/environment_specification.yml`.
+When a browser step fails, the test run prints the captured server output and
+stores a screenshot in the `screenshots/` directory. Open the printed screenshot
+path to inspect the page state at the failing step.
+
+For Behave browser tests, see the [Behave testing guide](behave.md).
 
 ## Documentation
 

--- a/docs/dev/translate.md
+++ b/docs/dev/translate.md
@@ -14,6 +14,16 @@ If your language is not listed, please request to add it!
 
 - [Translate on Weblate]({{link.weblate}})
 
+If your language is missing on Weblate, use Weblate's "Start new translation"
+or request the language in a project issue and include the language name and
+locale code. This helps maintainers enable the right plural rules and language
+selector entry.
+
+If you find a wrong translation, leave a Weblate comment or suggestion on the
+affected string. For broader wording issues, open a project issue and include
+the language, the page or calendar view where you saw the text, and the current
+and suggested wording.
+
 Here, you can see the current translation status:
 
 [![Translation status](https://hosted.weblate.org/widgets/open-web-calendar/-/multi-auto.svg)]({{link.weblate}})
@@ -38,6 +48,11 @@ I am not a native speaker, so my English is a bit clunky and your translation co
 
 - If you add a **new language**, you should also translate the calendar to it, especially the `language` and `language-en` strings so people can choose the language for the calendar from the drop down menu.
 - If you want your language to be featured at the top of the front page so people can click on it, you need at least 50% of the About Page and Configuration Page page.
+
+The `language` string is the language name as it should appear to speakers of
+that language, for example `Deutsch`. The `language-en` string is the English
+name, for example `German`. Keep both translated for new languages so users can
+recognize the language selector even when they do not understand the current UI.
 
 Have **fun** translating and thank you so much! If you have any questions, get in contact with me, @niccokunzmann.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -372,6 +372,7 @@ nav:
   - Development:
     - dev/translate.md
     - dev/index.md
+    - dev/behave.md
     - dev/api.md
     - dev/javascript.md
     - dev/maintain.md


### PR DESCRIPTION
## Summary
- fill the debug-mode command and screenshot workflow in the developer docs
- add a Behave browser testing guide covering feature files, fixtures, single-feature runs, browser/window options, screenshots, and reusable steps
- expand translation guidance for missing languages, wrong strings, and language selector strings

## Duplicate / scope check
- Fixes #1115
- Checked issue #1115 comments and assignees; no assignee or work claim was present
- Checked all PRs with: gh pr list --repo niccokunzmann/open-web-calendar --state all --search '1115 Improve Open Web Calendar contribution workflow' --json number,title,state,headRefName,author,url
- That PR search returned no matching PRs

## Verification
- git diff --check
- .venv/bin/reuse lint

## Local environment note
- A disposable-env MkDocs build was attempted with mkdocs.test.yml. The project-wide build did not complete locally after spending time on external asset downloads and host Cairo/social-card warnings; the one new link warning it surfaced was corrected to behave.md.