### PR TITLE
Preserve readable HTML text breaks in ICS fallback

### DIFF
--- a/open_web_calendar/clean_html.py
+++ b/open_web_calendar/clean_html.py
@@ -20,6 +20,7 @@ DEFAULT_SPEC = {
     "remove_tags": ("body", "div"),
 }
 HTML_TAG_MATCH = re.compile("<[^>]*>")
+HTML_TEXT_BREAK_TAGS = ("br", "div", "p", "li", "tr", "hr")
 
 
 def clean_html(bad_html: str, spec: dict) -> str:
@@ -55,4 +56,19 @@ def remove_html(html: str) -> str:
     return HTML_TAG_MATCH.sub("", html)
 
 
-__all__ = ["clean_html", "remove_html"]
+def html_to_text(html: str) -> str:
+    """Extract readable plain text from HTML.
+
+    Unlike remove_html(), this keeps natural line breaks for block and break
+    tags while preserving remove_html()'s compact historical behavior.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=MarkupResemblesLocatorWarning)
+        tree = BeautifulSoup(html, "html.parser")
+    for tag in tree.find_all(HTML_TEXT_BREAK_TAGS):
+        tag.append("\n")
+    lines = [line.strip() for line in tree.get_text().splitlines()]
+    return "\n".join(line for line in lines if line)
+
+
+__all__ = ["clean_html", "html_to_text", "remove_html"]

--- a/open_web_calendar/convert/ics.py
+++ b/open_web_calendar/convert/ics.py
@@ -12,7 +12,7 @@ from icalendar_compatibility import Description
 from mergecal import merge_calendars
 
 from open_web_calendar.calendars.base import Calendars
-from open_web_calendar.clean_html import remove_html
+from open_web_calendar.clean_html import html_to_text
 
 from .base import ConversionStrategy
 
@@ -71,7 +71,7 @@ class ConvertToICS(ConversionStrategy):
                 html = description.html
                 if not html:
                     continue
-                event["DESCRIPTION"] = description.text or remove_html(html)
+                event["DESCRIPTION"] = description.text or html_to_text(html)
                 if "X-ALT-DESC" not in event:
                     event.add("X-ALT-DESC", html, parameters={"FMTTYPE": "text/html"})
         return Response(calendar.to_ical(), mimetype="text/calendar")

--- a/open_web_calendar/test/test_clean.py
+++ b/open_web_calendar/test/test_clean.py
@@ -8,7 +8,7 @@ from pprint import pprint
 
 import pytest
 
-from open_web_calendar.clean_html import clean_html, remove_html
+from open_web_calendar.clean_html import clean_html, html_to_text, remove_html
 
 
 @pytest.mark.parametrize(
@@ -28,6 +28,17 @@ def test_remove_html():
     """Remove all HTML tags - we do not expect them in the summary."""
     assert remove_html("<asd>aaa</asd>bbb") == "aaabbb"
     assert remove_html("><<<>") == ">"
+
+
+def test_html_to_text_keeps_readable_breaks():
+    """Extract text from HTML while preserving meaningful line breaks."""
+    html = "<p>Breakfast<br>Eggs and toast</p><p>Lunch</p>"
+    assert html_to_text(html) == "Breakfast\nEggs and toast\nLunch"
+
+
+def test_html_to_text_keeps_inline_text_together():
+    """Inline formatting should not add noisy line breaks."""
+    assert html_to_text("A <strong>bold</strong> day") == "A bold day"
 
 
 def test_nice_id_for_event(client, calendar_urls):


### PR DESCRIPTION
## Summary
- add a dedicated `html_to_text()` helper that preserves block and `<br>` line breaks while leaving `remove_html()`'s compact contract unchanged
- use that helper when ICS DESCRIPTION fallback text has to be extracted from HTML-only event descriptions
- cover readable block breaks and inline formatting in focused clean-html tests

## Duplicate / competition check
- `gh issue view 1188 --repo niccokunzmann/open-web-calendar --comments` showed issue #1188 open, unassigned, and with no comments/work claim
- `gh pr list --repo niccokunzmann/open-web-calendar --state all --search "html_to_text OR remove_html OR Known limitation OR 1188"` found the merged parent PR #1185, but no active competing follow-up for #1188

## Verification
- `.venv/bin/python -m pytest open_web_calendar/test/test_clean.py open_web_calendar/test/test_issue_167_html_in_description.py -q`
- `.venv/bin/ruff check open_web_calendar/clean_html.py open_web_calendar/convert/ics.py open_web_calendar/test/test_clean.py`
- `git diff --check`