### PR TITLE
Preserve plain-text DESCRIPTION in event popup

### DIFF
--- a/open_web_calendar/convert/events.py
+++ b/open_web_calendar/convert/events.py
@@ -29,14 +29,14 @@ def is_date(date):
 
 
 class ConvertToEvents(ConversionStrategy):
-    """Convert events to dhtmlx. This conforms to a stratey pattern.
+    """Convert events to dhtmlx. This conforms to a strategy pattern.
 
     - timeshift_minutes is the timeshift specified by the calendar
         for dates.
     """
 
     def created(self):
-        """Set attribtues when created."""
+        """Set attributes when created."""
         try:
             self.timezone = zoneinfo.ZoneInfo(self.specification["timezone"])
         except (zoneinfo.ZoneInfoNotFoundError, ValueError):
@@ -204,10 +204,11 @@ class ConvertToEvents(ConversionStrategy):
     def get_event_description(self, event: Event):
         """Return a formatted description of the event.
 
-        HTML is cleaned.
+        HTML is cleaned. When the source has no HTML description,
+        the plain-text DESCRIPTION is used.
         """
-        description = Description(event).html
-        return self.clean_html(description)
+        description = Description(event)
+        return self.clean_html(description.html or description.text)
 
     def merge(self):
         return jsonify(self.components)

--- a/open_web_calendar/test/test_issue_443_plain_text_description.py
+++ b/open_web_calendar/test/test_issue_443_plain_text_description.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+"""A plain-text DESCRIPTION is preserved in the event popup.
+
+See https://github.com/niccokunzmann/open-web-calendar/issues/443
+
+The DHTMLX v7 popup was reported to drop the event description.
+The proximate cause is that ``get_event_description`` only returned
+``Description(event).html``, which is empty when the description is
+plain text (no HTML tags, no ALTREP, no X-ALT-DESC).
+"""
+
+from icalendar import Calendar, Event
+
+from open_web_calendar.app import ConvertToEvents
+
+
+def event_with_uid(calendar_content: str, uid: str) -> Event:
+    """Return the first event with the UID."""
+    calendar = Calendar.from_ical(calendar_content)
+    events = [event for event in calendar.walk("VEVENT") if event["UID"] == uid]
+    assert events
+    return events[0]
+
+
+def test_plain_text_description_is_preserved(calendar_content):
+    """A plain-text DESCRIPTION must round-trip into the event JSON."""
+    event = event_with_uid(
+        calendar_content["issue-287-links-1"], "1lnco7mmf4p8042a098k4h968g@google.com"
+    )
+    description = ConvertToEvents({"timezone": "Europe/London"}).get_event_description(
+        event
+    )
+    assert "Stroll down the original Main Street USA" in description
+
+
+def test_plain_text_description_with_url_is_preserved(calendar_content):
+    """Plain text containing URLs must not be mistaken for HTML and dropped."""
+    event = event_with_uid(
+        calendar_content["issue-287-links-1"], "2mq8bka1v6opsra23c1na99bcr@google.com"
+    )
+    description = ConvertToEvents({"timezone": "Europe/London"}).get_event_description(
+        event
+    )
+    assert "See attached flyer for details." in description


### PR DESCRIPTION
Fixes #443.

The 2025-01-17 commit 86f5792434 switched to `Description(event).html` from icalendar_compatibility, which returns an empty string for plain-text DESCRIPTION. Events with no HTML tags, ALTREP, or X-ALT-DESC silently lost their description in the popup. `get_event_description` now falls back to `Description.text` when the HTML branch is empty, restoring the pre-existing behaviour.