### PR TITLE
Fix typo: is_oragnizer → is_organizer in events JSON and calendar.js

### DIFF
--- a/open_web_calendar/convert/events.py
+++ b/open_web_calendar/convert/events.py
@@ -90,7 +90,7 @@ class ConvertToEvents(ConversionStrategy):
         if organizer is not None:
             participants.append(
                 cls.create_participant_from(
-                    organizer, role="ORGANIZER", is_oragnizer=True
+                    organizer, role="ORGANIZER", is_organizer=True
                 )
             )
         attendees = event.get("ATTENDEE", [])
@@ -105,7 +105,7 @@ class ConvertToEvents(ConversionStrategy):
         cls,
         address: vCalAddress,
         role: str = "REQ-PARTICIPANT",
-        is_oragnizer: bool = False,  # noqa: FBT001
+        is_organizer: bool = False,  # noqa: FBT001
     ) -> dict[str, Any]:
         """Create a participant with default values."""
         participant = {}
@@ -122,7 +122,7 @@ class ConvertToEvents(ConversionStrategy):
             f"PARTICIPANT-{pr}",
             f"PARTICIPANT-{status}",
         ]
-        participant["is_oragnizer"] = is_oragnizer
+        participant["is_organizer"] = is_organizer
         return participant
 
     def convert_ical_event(self, calendar_index, calendar_event: Event):

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -176,8 +176,8 @@ const template = {
         details.appendChild(summary);
         const ol = document.createElement("ol");
         for (const participant of participants) {
-            if ((participant.is_oragnizer && !specification.show_organizers) ||
-                (!participant.is_oragnizer && !specification.show_attendees)
+            if ((participant.is_organizer && !specification.show_organizers) ||
+                (!participant.is_organizer && !specification.show_attendees)
             ) {
                 continue;
             }


### PR DESCRIPTION
## Summary

Renames the participant flag from `is_oragnizer` to `is_organizer` across the events JSON output and the JS consumer in a single commit, as suggested in #1197.

Touches the five sites listed in the issue:

- [open_web_calendar/convert/events.py:93](open_web_calendar/convert/events.py#L93) — keyword arg at the call site
- [open_web_calendar/convert/events.py:108](open_web_calendar/convert/events.py#L108) — parameter name and default
- [open_web_calendar/convert/events.py:125](open_web_calendar/convert/events.py#L125) — dict key written into the participant
- [open_web_calendar/static/js/calendar.js:179-180](open_web_calendar/static/js/calendar.js#L179-L180) — two reads in the participant filter

Verified with a repo-wide grep that no occurrences of `is_oragnizer` remain.

## Breaking change note

The flag ships in the events JSON response (`/calendar.events.json`), so any user reading the JSON directly or targeting `participant.is_oragnizer` from custom JS will need to update to `is_organizer`. This matches the expectation called out in the issue.

## Test plan

- [x] `python3 -m py_compile open_web_calendar/convert/events.py`
- [x] `node --check open_web_calendar/static/js/calendar.js`
- [ ] Render an event with both an organizer and attendees and confirm `show_organizers` / `show_attendees` toggles still filter correctly
- [ ] Run the project test suite

Refs #1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)