### PR TITLE
Parse HTML in remove_html() instead of stripping with a regex

### DIFF
--- a/open_web_calendar/clean_html.py
+++ b/open_web_calendar/clean_html.py
@@ -8,7 +8,6 @@ This is important to mitigate attacks from ICS sources.
 See https://stackoverflow.com/questions/3073881/clean-up-html-in-python
 """
 
-import re
 import warnings
 
 from bs4 import BeautifulSoup, MarkupResemblesLocatorWarning
@@ -19,7 +18,6 @@ DEFAULT_SPEC = {
     "page_structure": True,
     "remove_tags": ("body", "div"),
 }
-HTML_TAG_MATCH = re.compile("<[^>]*>")
 
 
 def clean_html(bad_html: str, spec: dict) -> str:
@@ -51,8 +49,15 @@ def clean_html(bad_html: str, spec: dict) -> str:
 
 
 def remove_html(html: str) -> str:
-    """Remove all HTML from the html string and only return the text."""
-    return HTML_TAG_MATCH.sub("", html)
+    """Remove all HTML from the html string and only return the text.
+
+    Uses an HTML parser rather than a regex so malformed input like
+    ``><<<>`` is treated as text instead of being partially consumed,
+    and HTML entities (``&amp;``, ``&nbsp;``, ...) are unescaped.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=MarkupResemblesLocatorWarning)
+        return BeautifulSoup(html, "html.parser").get_text()
 
 
 __all__ = ["clean_html", "remove_html"]

--- a/open_web_calendar/test/test_clean.py
+++ b/open_web_calendar/test/test_clean.py
@@ -27,7 +27,12 @@ def test_clean_html_from_spec(html, spec, expected_output):
 def test_remove_html():
     """Remove all HTML tags - we do not expect them in the summary."""
     assert remove_html("<asd>aaa</asd>bbb") == "aaabbb"
-    assert remove_html("><<<>") == ">"
+    # Malformed input is treated as plain text by the HTML parser instead
+    # of being partially eaten by a regex (was ">" with the old regex).
+    assert remove_html("><<<>") == "><<<>"
+    # HTML entities are unescaped now that we parse the input.
+    assert remove_html("a&amp;b") == "a&b"
+    assert remove_html("plain text") == "plain text"
 
 
 def test_nice_id_for_event(client, calendar_urls):


### PR DESCRIPTION
## Summary

Addresses the follow-up noted in #1188 (originally from [PR #1185 comment](https://github.com/niccokunzmann/open-web-calendar/pull/1185#discussion_r3219021814)) — `remove_html()` used a `<[^>]*>` regex which has two real bugs the existing tests already documented:

1. **Malformed input is partially consumed.** `remove_html("><<<>")` returned `">"` because the regex greedily matched `<<<>` as one "tag". The old test on [test_clean.py:30](open_web_calendar/test/test_clean.py#L30) asserted this buggy output.
2. **HTML entities are never unescaped.** `&amp;`, `&nbsp;`, etc. survived in the output.

Switching the implementation to BeautifulSoup's `get_text()` fixes both. The well-formed case the contract care was about ([test_clean.py:29](open_web_calendar/test/test_clean.py#L29) — `<asd>aaa</asd>bbb` → `aaabbb`) is preserved byte-for-byte.

## Why this is safe

`remove_html()` is exported in `__all__` but, per `grep`, has **no callers anywhere in the codebase** outside its own tests. So the contract change is contained — only the test on line 30 (which was asserting the bug) needs updating.

## Changes

- [open_web_calendar/clean_html.py](open_web_calendar/clean_html.py) — `remove_html()` now uses `BeautifulSoup(html, "html.parser").get_text()`; removed the now-unused `import re` and `HTML_TAG_MATCH` regex.
- [open_web_calendar/test/test_clean.py](open_web_calendar/test/test_clean.py) — updated the `><<<>` assertion to the new (correct) output, plus added two cases covering entity unescape and plain-text passthrough.

## Note on `<br>` → newline

I deliberately did **not** pass `separator="\n"` to `get_text()`. Doing so would also change the well-formed case (`aaabbb` → `aaa\nbbb`), which is the exact contract the issue flagged as load-bearing. If preserving `<br>` as newlines is wanted, that's a small follow-up and the call site is now a one-liner to extend.

## Test plan

- [x] Verified all four assertions in `test_remove_html` pass locally against the new implementation
- [ ] `pytest open_web_calendar/test/test_clean.py` in CI

Refs #1188

🤖 Generated with [Claude Code](https://claude.com/claude-code)