### PR TITLE
Add config controls for event detail plugins

### DIFF
--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -376,6 +376,16 @@ SPDX-License-Identifier: GPL-2.0-only
                     <label for="menu_shows_calendar_visibility_toggle" ><div class="belongs-together button"><input type="checkbox" class="specification-checkbox"                            id="menu_shows_calendar_visibility_toggle" />{{ html("menu-shows-calendar-visibility")   }}</div></label>
                 </div>
             </section>
+            <section id="configure-event-details">
+                <h2>{{ html("event-details-title") }}</h2>
+                <p>
+                    {{ html("event-details-description") }}
+                </p>
+                <div class="action-paragraph">
+                    <label for="plugin_event_details"><div class="belongs-together button"><input type="checkbox" class="specification-checkbox" id="plugin_event_details" />{{ html("event-details-popup") }}</div></label>
+                    <label for="plugin_event_tooltip"><div class="belongs-together button"><input type="checkbox" class="specification-checkbox" id="plugin_event_tooltip" />{{ html("event-details-tooltip") }}</div></label>
+                </div>
+            </section>
             <section id="configure-timezone">
                 <h2>{{ html("timezone-title") }}</h2>
                 <p>

--- a/open_web_calendar/test/test_issue_1114_configuration_ui.py
+++ b/open_web_calendar/test/test_issue_1114_configuration_ui.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+
+def test_index_page_exposes_event_details_controls(client):
+    """The configuration UI exposes the existing event detail plugins."""
+    response = client.get("/index.html")
+
+    assert response.status_code == 200
+    assert 'id="configure-event-details"' in response.text
+    assert 'id="plugin_event_details"' in response.text
+    assert 'id="plugin_event_tooltip"' in response.text

--- a/open_web_calendar/translations/en/index.yml
+++ b/open_web_calendar/translations/en/index.yml
@@ -275,6 +275,11 @@ menu-shows-calendar-names: "List Calendar Names"
 menu-shows-calendar-descriptions: "List Calendar Descriptions"
 menu-shows-calendar-visibility: "Hide/Show Calendars"
 
+event-details-title: "Event Details"
+event-details-description: "Choose whether clicking an event opens quick info and whether hovering shows a tooltip."
+event-details-popup: "Show quick info on click"
+event-details-tooltip: "Show tooltip on hover"
+
 # Heading of option
 # https://open-web-calendar.hosted.quelltext.eu/#translate-timezone-title
 timezone-title: "Time Zone"

--- a/open_web_calendar/translations/en/index.yml
+++ b/open_web_calendar/translations/en/index.yml
@@ -276,8 +276,8 @@ menu-shows-calendar-descriptions: "List Calendar Descriptions"
 menu-shows-calendar-visibility: "Hide/Show Calendars"
 
 event-details-title: "Event Details"
-event-details-description: "Choose whether clicking an event opens quick info and whether hovering shows a tooltip."
-event-details-popup: "Show quick info on click"
+event-details-description: "Choose whether clicking an event shows its details and whether hovering shows a tooltip."
+event-details-popup: "Show event details on click"
 event-details-tooltip: "Show tooltip on hover"
 
 # Heading of option


### PR DESCRIPTION
## Summary
- add configuration page controls for the existing event detail popup and tooltip spec keys
- reuse the existing specification-checkbox wiring so the new controls update the generated calendar URL
- cover the new section with a focused index page test

Closes #1114