### PR TITLE
Sanitize X-ALT-DESC HTML in ICS output

### DIFF
--- a/open_web_calendar/convert/ics.py
+++ b/open_web_calendar/convert/ics.py
@@ -72,8 +72,10 @@ class ConvertToICS(ConversionStrategy):
                 if not html:
                     continue
                 event["DESCRIPTION"] = description.text or remove_html(html)
-                if "X-ALT-DESC" not in event:
-                    event.add("X-ALT-DESC", html, parameters={"FMTTYPE": "text/html"})
+                safe_html = self.clean_html(html)
+                if "X-ALT-DESC" in event:
+                    del event["X-ALT-DESC"]
+                event.add("X-ALT-DESC", safe_html, parameters={"FMTTYPE": "text/html"})
         return Response(calendar.to_ical(), mimetype="text/calendar")
 
 

--- a/open_web_calendar/features/calendars/issue-1187-xss-promoted.ics
+++ b/open_web_calendar/features/calendars/issue-1187-xss-promoted.ics
@@ -1,0 +1,12 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Issue 1187 fixture//EN
+BEGIN:VEVENT
+UID:issue-1187-promoted@example.com
+DTSTAMP:20260101T000000Z
+DTSTART:20260101T100000Z
+DTEND:20260101T110000Z
+SUMMARY:Event with HTML in DESCRIPTION (promoted to X-ALT-DESC)
+DESCRIPTION:<p>Hello</p><script>alert('XSS-promoted')</script><img src=x onerror="alert(1)">
+END:VEVENT
+END:VCALENDAR

--- a/open_web_calendar/features/calendars/issue-1187-xss-x-alt-desc.ics
+++ b/open_web_calendar/features/calendars/issue-1187-xss-x-alt-desc.ics
@@ -1,0 +1,13 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Issue 1187 fixture//EN
+BEGIN:VEVENT
+UID:issue-1187-x-alt-desc@example.com
+DTSTAMP:20260101T000000Z
+DTSTART:20260101T100000Z
+DTEND:20260101T110000Z
+SUMMARY:Event with malicious X-ALT-DESC from source
+DESCRIPTION:Plain text fallback
+X-ALT-DESC;FMTTYPE=text/html:<p>Hello</p><script>alert('XSS-source')</script><img src=x onerror="alert(2)">
+END:VEVENT
+END:VCALENDAR

--- a/open_web_calendar/test/test_issue_1187_sanitize_x_alt_desc.py
+++ b/open_web_calendar/test/test_issue_1187_sanitize_x_alt_desc.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+"""X-ALT-DESC HTML in /calendar.ics output must be sanitized.
+
+See https://github.com/niccokunzmann/open-web-calendar/issues/1187
+
+Two paths produce X-ALT-DESC HTML in the merged ICS feed:
+
+1. DESCRIPTION HTML promoted to X-ALT-DESC by the #167 fix (PR #1185)
+2. X-ALT-DESC carried verbatim from a source event
+
+Both paths previously copied HTML through without sanitization, so a
+malicious source calendar could ship `<script>` or event-handler
+payloads to every subscriber of the merged feed.
+"""
+
+from icalendar_compatibility import Description
+
+
+def event_by_uid(cal, uid):
+    return next(e for e in cal.events if str(e.get("UID", "")) == uid)
+
+
+def test_promoted_x_alt_desc_is_sanitized(merged):
+    """HTML promoted from DESCRIPTION to X-ALT-DESC must be cleaned."""
+    cal = merged(["issue-1187-xss-promoted"])
+    event = event_by_uid(cal, "issue-1187-promoted@example.com")
+    x_alt = str(event["X-ALT-DESC"])
+    assert "<script>" not in x_alt
+    assert "alert(" not in x_alt
+    assert "onerror" not in x_alt
+    assert Description.this_could_be_html(x_alt)
+
+
+def test_source_x_alt_desc_is_sanitized(merged):
+    """X-ALT-DESC carried over from the source event must be cleaned."""
+    cal = merged(["issue-1187-xss-x-alt-desc"])
+    event = event_by_uid(cal, "issue-1187-x-alt-desc@example.com")
+    x_alt = str(event["X-ALT-DESC"])
+    assert "<script>" not in x_alt
+    assert "alert(" not in x_alt
+    assert "onerror" not in x_alt
+    assert Description.this_could_be_html(x_alt)

--- a/open_web_calendar/test/test_issue_167_html_in_description.py
+++ b/open_web_calendar/test/test_issue_167_html_in_description.py
@@ -61,12 +61,12 @@ def test_altrep_html_is_normalised(merged):
     assert Description.this_could_be_html(str(x_alt))
 
 
-def test_existing_x_alt_desc_is_preserved(merged):
+def test_existing_x_alt_desc_is_sanitized(merged):
     """When the source already has X-ALT-DESC;FMTTYPE=text/html, the HTML
-    is preserved verbatim (no overwrite)."""
+    is sanitized but the content survives (see #1187)."""
     cal = merged(["food"])
     event = event_by_uid(cal, "2845")
     x_alt = event["X-ALT-DESC"]
     assert x_alt.params.get("FMTTYPE") == "text/html"
-    # Source X-ALT-DESC starts with this DOCTYPE; verify it wasn't overwritten.
-    assert str(x_alt).startswith("<!DOCTYPE HTML")
+    assert Description.this_could_be_html(str(x_alt))
+    assert "Breakfast" in str(x_alt)


### PR DESCRIPTION
Fixes #1187.

`/calendar.ics` previously copied X-ALT-DESC HTML straight from sources — both when promoting DESCRIPTION HTML to X-ALT-DESC (#1185) and when the source already carried X-ALT-DESC;FMTTYPE=text/html. The merge step now runs both flows through the same `clean_html` cleaner that `/calendar.events.json` uses.