### PR TITLE
Escape exception details in 500 error page

### DIFF
--- a/open_web_calendar/app.py
+++ b/open_web_calendar/app.py
@@ -370,35 +370,9 @@ def serve_js_proxy():
 
 @app.errorhandler(500)
 def unhandled_exception(error):
-    """Called when an error occurs.
-
-    See https://stackoverflow.com/q/14993318
-    """
-    trace = (
-        f"<pre>\r\n{traceback.format_exc()}</pre>"
-        if config.debug
-        else "Trace only available if DEBUG=true."
-    )
-    return (
-        f"""
-    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-    <html>
-        <head>
-            <title>500 Internal Server Error</title>
-        </head>
-        <body>
-            <h1>Internal Server Error</h1>
-            <p>
-                The server encountered an internal error and was unable to
-                complete your request.  Either the server is overloaded or
-                there is an error in the application.
-            </p>
-            {trace}
-        </body>
-    </html>
-    """,
-        http_status_code_for_error(error),
-    )  # return error code from https://stackoverflow.com/a/7824605
+    """Called when an error occurs."""
+    trace = traceback.format_exc() if config.debug else None
+    return render_template("500.html", trace=trace), http_status_code_for_error(error)
 
 
 @app.post("/encrypt")

--- a/open_web_calendar/templates/500.html
+++ b/open_web_calendar/templates/500.html
@@ -1,0 +1,24 @@
+<!--
+SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+
+SPDX-License-Identifier: GPL-2.0-only
+-->
+
+<!DOCTYPE html>
+<html>
+<head>
+  <title>500 Internal Server Error</title>
+</head>
+<body>
+
+<h1>Internal Server Error</h1>
+<p>The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.</p>
+
+{% if trace %}
+<pre>{{ trace }}</pre>
+{% else %}
+<p>Trace only available if DEBUG=true.</p>
+{% endif %}
+
+</body>
+</html>

--- a/open_web_calendar/test/test_issue_479_escape_500_error_page.py
+++ b/open_web_calendar/test/test_issue_479_escape_500_error_page.py
@@ -73,12 +73,17 @@ def test_500_in_debug_escapes_script_tag_in_exception_message(
     client, debug, errors_propagate_to_handler
 ):
     """An attacker-controlled <script> tag in the ValueError message must
-    appear HTML-escaped in the 500 response (NF-006)."""
-    response = client.get("/calendar.%3Cscript%3Ealert(1)%3C/script%3E")
+    appear HTML-escaped in the 500 response (NF-006).
+
+    The URL converter rejects encoded slashes, so this exercises the
+    opening-tag payload only. The closing-tag case is covered by the
+    direct-handler-call test below, which is not subject to URL routing.
+    """
+    response = client.get("/calendar.%3Cscript%3E")
     assert response.status_code == 500
     body = response.data.decode("utf-8")
-    assert "<script>alert(1)</script>" not in body
-    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
+    assert "<script>" not in body
+    assert "&lt;script&gt;" in body
 
 
 def _raise_xss_payload():

--- a/open_web_calendar/test/test_issue_479_escape_500_error_page.py
+++ b/open_web_calendar/test/test_issue_479_escape_500_error_page.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+"""The 500 error page must HTML-escape interpolated values.
+
+See https://github.com/niccokunzmann/open-web-calendar/issues/479
+Addresses pentest finding NF-006 ("Potential XSS in error 500 handling").
+
+The pentest report says:
+
+    Once fixed, it could become an XSS vector, as the content of the
+    stack trace and ValueError is embedded in the returned HTML without
+    sanitization. An attacker could deliberately trigger an error and
+    use the controllable parts of the stack trace or ValueError to
+    inject HTML into the response.
+
+These tests cover both:
+- the route-level path (a real 500 dispatched through Flask's error handler)
+- the unit-level handler call (the handler escapes regardless of dispatch)
+"""
+
+import pytest
+
+from open_web_calendar.app import unhandled_exception
+from open_web_calendar.config import environment
+
+
+@pytest.fixture()
+def debug():
+    """Force debug mode on so the traceback is rendered."""
+    original = environment.debug
+    environment.debug = True
+    yield
+    environment.debug = original
+
+
+@pytest.fixture()
+def errors_propagate_to_handler(app):
+    """Flask's TESTING=True re-raises uncaught exceptions instead of
+    dispatching them to error handlers. These tests need the real handler."""
+    original_testing = app.testing
+    original_propagate = app.config.get("PROPAGATE_EXCEPTIONS")
+    app.testing = False
+    app.config["PROPAGATE_EXCEPTIONS"] = False
+    yield
+    app.testing = original_testing
+    app.config["PROPAGATE_EXCEPTIONS"] = original_propagate
+
+
+def test_500_in_production_has_no_traceback(
+    client, production, errors_propagate_to_handler
+):
+    """In production, the 500 page must not leak traceback or internals."""
+    response = client.get("/calendar.notavalidext")
+    assert response.status_code == 500
+    body = response.data.decode("utf-8")
+    assert "Traceback" not in body
+    assert "<pre>" not in body
+    assert "open_web_calendar" not in body
+
+
+def test_500_in_debug_includes_traceback(client, debug, errors_propagate_to_handler):
+    """In debug, the 500 page must show the traceback (fixes #479's reporter ask)."""
+    response = client.get("/calendar.notavalidext")
+    assert response.status_code == 500
+    body = response.data.decode("utf-8")
+    assert "Traceback" in body
+    assert "ValueError" in body
+
+
+def test_500_in_debug_escapes_script_tag_in_exception_message(
+    client, debug, errors_propagate_to_handler
+):
+    """An attacker-controlled <script> tag in the ValueError message must
+    appear HTML-escaped in the 500 response (NF-006)."""
+    response = client.get("/calendar.%3Cscript%3Ealert(1)%3C/script%3E")
+    assert response.status_code == 500
+    body = response.data.decode("utf-8")
+    assert "<script>alert(1)</script>" not in body
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
+
+
+def _raise_xss_payload():
+    """Raise an exception whose message carries an XSS payload."""
+    raise ValueError("<img src=x onerror=alert(1)>")
+
+
+def test_500_escapes_via_direct_handler_call(app, debug):
+    """Defense-in-depth: the handler escapes regardless of routing."""
+    with app.test_request_context("/"):
+        try:
+            _raise_xss_payload()
+        except ValueError as exc:
+            response_body, status = unhandled_exception(exc)
+    assert status == 500
+    assert "<img src=x onerror=alert(1)>" not in response_body
+    assert "&lt;img src=x onerror=alert(1)&gt;" in response_body
+
+
+def test_500_response_is_html(client, errors_propagate_to_handler):
+    """The 500 response advertises HTML content type."""
+    response = client.get("/calendar.notavalidext")
+    assert response.status_code == 500
+    assert response.content_type.startswith("text/html")


### PR DESCRIPTION
Fixes #479. Addresses pentest finding NF-006.

The 500 handler interpolated `traceback.format_exc()` into HTML with an f-string, so an attacker-controlled exception message could inject live HTML once the traceback was shown. The handler now renders a Jinja2 template, auto-escaping the trace. Traceback is shown in debug and suppressed in production as before.

See also: #595.