### PR TITLE
Remove duplicate translate link

### DIFF
--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -123,7 +123,6 @@ SPDX-License-Identifier: GPL-2.0-only
                             <span id="language-chosen"></span>
                         </div>
                     </fieldset>
-                    <a href="{{ specification['translate'] }}">{{ html("translate") }}</a>
                 </div>
             </section>
             <section id="configure-title">

--- a/open_web_calendar/test/test_issue_1096_translate_link.py
+++ b/open_web_calendar/test/test_issue_1096_translate_link.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+from open_web_calendar.app import get_default_specification
+
+
+def test_translate_link_is_shown_once_in_language_section(client):
+    """The language section should not repeat the translate link."""
+    response = client.get("/index.html#configure-languages")
+
+    assert response.status_code == 200
+    translate_url = get_default_specification()["translate"]
+    assert response.text.count(f'href="{translate_url}"') == 1


### PR DESCRIPTION
## Summary
- remove the second Weblate translate link from the language configuration section
- add a regression test that the rendered index page only includes one translate link

Fixes #1096

## Verification
- .venv/bin/python -m pytest open_web_calendar/test/test_issue_1096_translate_link.py 'open_web_calendar/test/test_version.py::test_version_in_footer[index.html]'
- .venv/bin/ruff check open_web_calendar/test/test_issue_1096_translate_link.py
- .venv/bin/reuse lint
- git diff --check