### PR TITLE
Add Home link to configuration navigation

### DIFF
--- a/open_web_calendar/default_specification.yml
+++ b/open_web_calendar/default_specification.yml
@@ -265,6 +265,9 @@ clean_html_remove_tags:
 ## This is required by GPL.
 source_code: "https://github.com/niccokunzmann/open-web-calendar/"
 
+## This is a link to the project homepage.
+homepage: "https://open-web-calendar.quelltext.eu/"
+
 ## You can override the version text next to the source code link.
 ## If this is empty, the version of the package is used.
 version: ''

--- a/open_web_calendar/static/js/navigation.js
+++ b/open_web_calendar/static/js/navigation.js
@@ -115,6 +115,10 @@ function scrollToCurrentSection() {
         previousSectionLink.href = bottomPreviousLink.href = "#" + currentSection.owcPreviousSection.id;
         previousSectionLink.innerText = currentSection.owcPreviousSection.owcHeading;
         document.body.classList.remove("no-previous-section");
+    } else if (homepageUrl) {
+        previousSectionLink.href = bottomPreviousLink.href = homepageUrl;
+        previousSectionLink.innerText = bottomPreviousLink.innerText = translations["home"];
+        document.body.classList.remove("no-previous-section");
     } else {
         document.body.classList.add("no-previous-section");
     }

--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -19,7 +19,9 @@ SPDX-License-Identifier: GPL-2.0-only
                 "button-encrypted": {{ string("button-encrypted") | tojson }},
                 "button-edit": {{ string("button-edit") | tojson }},
                 "button-remove": {{ string("button-remove") | tojson }},
+                "home": {{ string("home") | tojson }},
             };
+            const homepageUrl = {{ specification["homepage"] | tojson | safe }};
         </script>
         <link href="css/common.css" rel="stylesheet" type="text/css">
         <link href="css/index.css" rel="stylesheet" type="text/css">

--- a/open_web_calendar/test/test_issue_1095_home_link.py
+++ b/open_web_calendar/test/test_issue_1095_home_link.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2026 Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+from open_web_calendar.app import get_default_specification
+
+
+def test_index_page_exposes_home_navigation_data(client):
+    """The configuration page should expose data for a home navigation link."""
+    response = client.get("/index.html")
+
+    assert response.status_code == 200
+    assert '"home": "Home"' in response.text
+    assert f'const homepageUrl = "{get_default_specification()["homepage"]}";' in (
+        response.text
+    )

--- a/open_web_calendar/translations/en/common.yml
+++ b/open_web_calendar/translations/en/common.yml
@@ -28,6 +28,10 @@ improve: "Help improve the project and learn how to contribute."
 # https://open-web-calendar.hosted.quelltext.eu/
 project-name: "Open Web Calendar"
 
+# This is a navigation link leading to the project homepage.
+# https://open-web-calendar.hosted.quelltext.eu/
+home: "Home"
+
 
 # This is a link in the footer of the index and on the about page leading to the project's privacy policy.
 # https://open-web-calendar.hosted.quelltext.eu/#translate-privacy-policy
@@ -39,5 +43,4 @@ privacy-policy: "Privacy Policy"
 # https://open-web-calendar.hosted.quelltext.eu/#translate-version
 # https://open-web-calendar.hosted.quelltext.eu/about.html#translate-version
 version: "Version: {version}"
-
 


### PR DESCRIPTION
## Summary
- add a configurable homepage URL and English `Home` navigation label
- show `Home` as the previous navigation target when the configuration page is on its first section
- keep normal previous-section navigation for later sections

Fixes #1095

## Verification
- .venv/bin/python -m pytest open_web_calendar/test/test_issue_1095_home_link.py 'open_web_calendar/test/test_version.py::test_version_in_footer[index.html]'
- .venv/bin/ruff check open_web_calendar/test/test_issue_1095_home_link.py
- node --check open_web_calendar/static/js/navigation.js
- .venv/bin/reuse lint
- git diff --check
- browser smoke: first section previous link shows Home -> https://open-web-calendar.quelltext.eu/; #configure-title previous link remains #configure-languages