### PR TITLE
Add OWC_ENABLE_JS env var to disable user-supplied JavaScript

### DIFF
--- a/docs/host/configure.md
+++ b/docs/host/configure.md
@@ -157,9 +157,10 @@ Examples:
 default `true`, values `true` or `false`
 
 When set to `false`, user-supplied JavaScript via the `javascript` and `javascript_url`
-spec keys is silently dropped from query strings and from `specification_url` JSON,
-and `/js/proxy` returns 403. JavaScript set in `default_specification.yml` or the
-`OWC_SPECIFICATION` env var still works (admin-trusted).
+spec keys is silently dropped from query strings and from the body fetched via
+`specification_url`, and `/js/proxy` returns 403. JavaScript set in
+`default_specification.yml` or the `OWC_SPECIFICATION` env var still works
+(admin-trusted).
 
 This is a defense-in-depth layer on top of `Content-Security-Policy` for instances
 hosted on the **same domain or sub-path** as another service: with JavaScript enabled,

--- a/docs/host/configure.md
+++ b/docs/host/configure.md
@@ -158,9 +158,9 @@ default `true`, values `true` or `false`
 
 When set to `false`, user-supplied JavaScript via the `javascript` and `javascript_url`
 spec keys is silently dropped from query strings and from the body fetched via
-`specification_url`, and `/js/proxy` returns 403. JavaScript set in
-`default_specification.yml` or the `OWC_SPECIFICATION` env var still works
-(admin-trusted).
+`specification_url`. JavaScript set in `default_specification.yml` or the
+`OWC_SPECIFICATION` env var still works (admin-trusted), including absolute
+`javascript_url` entries that proxy through `/js/proxy`.
 
 This is a defense-in-depth layer on top of `Content-Security-Policy` for instances
 hosted on the **same domain or sub-path** as another service: with JavaScript enabled,

--- a/docs/host/configure.md
+++ b/docs/host/configure.md
@@ -152,6 +152,24 @@ Examples:
 - Refresh fast: `CACHE_REQUESTED_URLS_FOR_SECONDS=10`
 - Disable caching: `CACHE_REQUESTED_URLS_FOR_SECONDS=0`
 
+### OWC_ENABLE_JS
+
+default `true`, values `true` or `false`
+
+When set to `false`, user-supplied JavaScript via the `javascript` and `javascript_url`
+spec keys is silently dropped from query strings and from `specification_url` JSON,
+and `/js/proxy` returns 403. JavaScript set in `default_specification.yml` or the
+`OWC_SPECIFICATION` env var still works (admin-trusted).
+
+This is a defense-in-depth layer on top of `Content-Security-Policy` for instances
+hosted on the **same domain or sub-path** as another service: with JavaScript enabled,
+an attacker-controlled URL could execute arbitrary JS in the parent service's origin.
+By default OWC assumes it runs on its own subdomain with no shared cookies or state.
+
+Even with `OWC_ENABLE_JS=false`, hosts on shared domains should also set a strict
+`Content-Security-Policy` header — this env var prevents OWC from injecting attacker
+JS but does not by itself isolate OWC from the parent origin.
+
 ### OWC_ENCRYPTION_KEYS
 
 default empty

--- a/open_web_calendar/app.py
+++ b/open_web_calendar/app.py
@@ -370,8 +370,6 @@ def serve_locale(lang):
 @allowed_hosts.limit()
 def serve_js_proxy():
     """Proxy a remote script and re-serve it as text/javascript."""
-    if not config.enable_js:
-        return "JavaScript is disabled on this instance", 403
     url = request.args.get("url")
     if not url:
         return "Missing url parameter", 400

--- a/open_web_calendar/app.py
+++ b/open_web_calendar/app.py
@@ -59,6 +59,8 @@ DEFAULT_REQUEST_HEADERS = {
 
 # specification
 PARAM_SPECIFICATION_URL = "specification_url"
+# Spec keys gated by OWC_ENABLE_JS — see issue #563.
+JS_SPEC_KEYS = ("javascript", "javascript_url")
 TIMEZONES = list(zoneinfo.available_timezones())
 TIMEZONES.sort()
 
@@ -204,8 +206,14 @@ def get_specification(query=None):
     if url:
         url_specification_response = get_text_from_url(url)
         url_specification_values = yaml.safe_load(url_specification_response)
+        if not config.enable_js:
+            for js_key in JS_SPEC_KEYS:
+                url_specification_values.pop(js_key, None)
         specification.update(url_specification_values)
     for parameter in query:
+        # OWC_ENABLE_JS=false drops JS keys from untrusted query params; see #563.
+        if not config.enable_js and parameter in JS_SPEC_KEYS:
+            continue
         # get a list of arguments
         # see https://web.archive.org/web/20230325034825/https://werkzeug.palletsprojects.com/en/0.14.x/datastructures/
         value = query.getlist(parameter)
@@ -362,6 +370,8 @@ def serve_locale(lang):
 @allowed_hosts.limit()
 def serve_js_proxy():
     """Proxy a remote script and re-serve it as text/javascript."""
+    if not config.enable_js:
+        return "JavaScript is disabled on this instance", 403
     url = request.args.get("url")
     if not url:
         return "Missing url parameter", 400

--- a/open_web_calendar/config.py
+++ b/open_web_calendar/config.py
@@ -98,6 +98,15 @@ class Config:
         return self._source.get("APP_DEBUG", "").lower() == "true"
 
     @config_property
+    def enable_js(self) -> bool:
+        """Whether user-supplied JavaScript is allowed.
+
+        Variable: OWC_ENABLE_JS
+        Default: True
+        """
+        return self._source.get("OWC_ENABLE_JS", "true").lower() != "false"
+
+    @config_property
     def cache_expire_after(self) -> int:
         """The cache expiration timeout in seconds.
 

--- a/open_web_calendar/test/test_issue_563_owc_enable_js.py
+++ b/open_web_calendar/test/test_issue_563_owc_enable_js.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+"""OWC_ENABLE_JS gates user-supplied JavaScript.
+
+See https://github.com/niccokunzmann/open-web-calendar/issues/563
+
+When the env var is set to `false`, the `javascript` and `javascript_url`
+spec keys are silently dropped from query strings and from
+specification_url JSON. JavaScript set in default_specification.yml or
+the OWC_SPECIFICATION env var still works (admin-trusted). The
+/js/proxy route returns 403 so direct attempts also fail.
+
+The default is `true` for backward compatibility with OWC's standard
+"own subdomain" deployment model.
+"""
+
+import os
+
+from werkzeug.datastructures import MultiDict
+
+from open_web_calendar.app import DEFAULT_SPECIFICATION, get_specification
+
+
+def test_default_enables_js_from_query():
+    """Default env: javascript query param is honoured."""
+    spec = get_specification(query=MultiDict({"javascript": "alert(1)"}))
+    assert spec["javascript"] == "alert(1)"
+
+
+def test_default_enables_js_url_from_query():
+    """Default env: javascript_url query param is honoured."""
+    spec = get_specification(query=MultiDict({"javascript_url": "/feature.js"}))
+    assert spec["javascript_url"] == ["/feature.js"]
+
+
+def test_disable_drops_js_from_query(monkeypatch):
+    """OWC_ENABLE_JS=false: javascript query param is silently dropped."""
+    monkeypatch.setitem(os.environ, "OWC_ENABLE_JS", "false")
+    spec = get_specification(query=MultiDict({"javascript": "alert(1)"}))
+    assert spec["javascript"] == ""
+
+
+def test_disable_drops_js_url_from_query(monkeypatch):
+    """OWC_ENABLE_JS=false: javascript_url query param is silently dropped."""
+    monkeypatch.setitem(os.environ, "OWC_ENABLE_JS", "false")
+    spec = get_specification(query=MultiDict({"javascript_url": "/x.js"}))
+    assert spec["javascript_url"] == []
+
+
+def test_disable_drops_js_from_specification_url(monkeypatch, cache_url):
+    """OWC_ENABLE_JS=false: javascript in a fetched specification_url is dropped."""
+    monkeypatch.setitem(os.environ, "OWC_ENABLE_JS", "false")
+    spec_url = "https://example.com/spec.yml"
+    cache_url(spec_url, 'javascript: "alert(1)"\njavascript_url: ["/x.js"]\n')
+    spec = get_specification(query=MultiDict({"specification_url": spec_url}))
+    assert spec["javascript"] == ""
+    assert spec["javascript_url"] == []
+
+
+def test_disable_keeps_admin_supplied_js_from_app_default(monkeypatch):
+    """OWC_ENABLE_JS=false: JS from the in-app DEFAULT_SPECIFICATION still works."""
+    monkeypatch.setitem(os.environ, "OWC_ENABLE_JS", "false")
+    monkeypatch.setitem(DEFAULT_SPECIFICATION, "javascript", "console.log('admin')")
+    spec = get_specification(query=MultiDict({}))
+    assert spec["javascript"] == "console.log('admin')"
+
+
+def test_disable_returns_403_from_js_proxy(client, monkeypatch):
+    """OWC_ENABLE_JS=false: /js/proxy returns 403."""
+    monkeypatch.setitem(os.environ, "OWC_ENABLE_JS", "false")
+    response = client.get("/js/proxy?url=http://example.com/x.js")
+    assert response.status_code == 403
+
+
+def test_default_allows_js_proxy(client, cache_url):
+    """Default env: /js/proxy serves the script."""
+    js_url = "http://example.com/x.js"
+    cache_url(js_url, "console.log('ok');")
+    response = client.get(f"/js/proxy?url={js_url}")
+    assert response.status_code == 200
+    assert b"console.log('ok');" in response.data
+
+
+def test_disable_does_not_affect_css(monkeypatch):
+    """OWC_ENABLE_JS=false: css and css_url query params still work."""
+    monkeypatch.setitem(os.environ, "OWC_ENABLE_JS", "false")
+    spec = get_specification(
+        query=MultiDict({"css": "body{color:red}", "css_url": "/style.css"})
+    )
+    assert spec["css"] == "body{color:red}"
+    assert spec["css_url"] == ["/style.css"]

--- a/open_web_calendar/test/test_issue_563_owc_enable_js.py
+++ b/open_web_calendar/test/test_issue_563_owc_enable_js.py
@@ -10,8 +10,8 @@ When the env var is set to `false`, the `javascript` and `javascript_url`
 spec keys are silently dropped from query strings and from the body
 fetched via `specification_url`. JavaScript set in
 `default_specification.yml` or the `OWC_SPECIFICATION` env var still
-works (admin-trusted). The `/js/proxy` route returns 403 so direct
-attempts also fail.
+works (admin-trusted), including admin-supplied absolute `javascript_url`
+entries that proxy through `/js/proxy`.
 
 The default is `true` for backward compatibility with OWC's standard
 "own subdomain" deployment model.
@@ -68,11 +68,14 @@ def test_disable_keeps_admin_supplied_js_from_app_default(monkeypatch):
     assert spec["javascript"] == "console.log('admin')"
 
 
-def test_disable_returns_403_from_js_proxy(client, monkeypatch):
-    """OWC_ENABLE_JS=false: /js/proxy returns 403."""
+def test_disable_keeps_admin_js_url_working_via_proxy(client, cache_url, monkeypatch):
+    """OWC_ENABLE_JS=false: admin-trusted absolute javascript_url still proxies."""
     monkeypatch.setitem(os.environ, "OWC_ENABLE_JS", "false")
-    response = client.get("/js/proxy?url=http://example.com/x.js")
-    assert response.status_code == 403
+    js_url = "http://example.com/admin.js"
+    cache_url(js_url, "console.log('admin');")
+    response = client.get(f"/js/proxy?url={js_url}")
+    assert response.status_code == 200
+    assert b"console.log('admin');" in response.data
 
 
 def test_default_allows_js_proxy(client, cache_url):

--- a/open_web_calendar/test/test_issue_563_owc_enable_js.py
+++ b/open_web_calendar/test/test_issue_563_owc_enable_js.py
@@ -7,10 +7,11 @@
 See https://github.com/niccokunzmann/open-web-calendar/issues/563
 
 When the env var is set to `false`, the `javascript` and `javascript_url`
-spec keys are silently dropped from query strings and from
-specification_url JSON. JavaScript set in default_specification.yml or
-the OWC_SPECIFICATION env var still works (admin-trusted). The
-/js/proxy route returns 403 so direct attempts also fail.
+spec keys are silently dropped from query strings and from the body
+fetched via `specification_url`. JavaScript set in
+`default_specification.yml` or the `OWC_SPECIFICATION` env var still
+works (admin-trusted). The `/js/proxy` route returns 403 so direct
+attempts also fail.
 
 The default is `true` for backward compatibility with OWC's standard
 "own subdomain" deployment model.


### PR DESCRIPTION
Fixes #563. Adds the "second layer of security" for same-domain hosting.

New `OWC_ENABLE_JS` env var (default `true`). When `false`, `javascript` and `javascript_url` are silently dropped from query strings and from the body fetched via `specification_url`. JS in `default_specification.yml` and the `OWC_SPECIFICATION` env var still works (admin-trusted), including absolute `javascript_url` entries that proxy through `/js/proxy`. Documented in `docs/host/configure.md`.

See also: #595.
