### PR TITLE
Cap event count and JSON size to mitigate recurring-event DoS

### DIFF
--- a/docs/host/configure.md
+++ b/docs/host/configure.md
@@ -226,10 +226,10 @@ This addresses pentest finding CLN-007 (recurring-event denial of service).
 
 default `1000` (events)
 
-The maximum number of `VEVENT` components accepted in a single source
-calendar. This is a pre-expansion cap that rejects abnormally large source
-calendars before the recurring-event expansion step runs. When exceeded,
-the request returns HTTP 413.
+The maximum number of `VEVENT` components accepted from a single fetched
+ICS payload, summed across all `VCALENDAR` blocks in that payload. This is a
+pre-expansion cap that rejects abnormally large source calendars before the
+recurring-event expansion step runs. When exceeded, the request returns HTTP 413.
 
 This addresses pentest finding CLN-007 (recurring-event denial of service).
 

--- a/docs/host/configure.md
+++ b/docs/host/configure.md
@@ -198,6 +198,37 @@ See also:
 [Fernet]: https://cryptography.io/en/latest/fernet/
 [/new-key]: {{ link.web }}/new-key
 
+### OWC_MAX_RESPONSE_EVENTS
+
+default `10000` (events)
+
+The maximum number of expanded events returned by `/calendar.events.json`.
+Recurring events expand into one entry per occurrence, so a small ICS with
+a long RRULE can balloon into millions of events. When the expanded count
+exceeds this cap, the request returns HTTP 413.
+
+This addresses pentest finding CLN-007 (recurring-event denial of service).
+
+### OWC_MAX_RESPONSE_MB
+
+default `10` (MB)
+
+The maximum byte size of the JSON body returned by `/calendar.events.json`.
+When the serialized response exceeds this cap, the request returns HTTP 413.
+
+This addresses pentest finding CLN-007 (recurring-event denial of service).
+
+### OWC_MAX_SOURCE_EVENTS
+
+default `1000` (events)
+
+The maximum number of `VEVENT` components accepted in a single source
+calendar. This is a pre-expansion cap that rejects abnormally large source
+calendars before the recurring-event expansion step runs. When exceeded,
+the request returns HTTP 413.
+
+This addresses pentest finding CLN-007 (recurring-event denial of service).
+
 ### OWC_SPECIFICATION
 
 [OWC_SPECIFICATION]: #owc_specification
@@ -260,7 +291,7 @@ The Open Web Calendar relies on proxy servers for these features:
 - **HTTPS Encryption**  
   This can be done by `nginx`, `apache` or `caddy`.
 - **More Advanced Caching**  
-  Basic caching is handeled by the Open Web Calendar.
+  Basic caching is handled by the Open Web Calendar.
   For more advanced cache configuration, use a proxy server like `squid`.
   Have a look in the documentation below on how to make the Open Web Calendar access the web only through a proxy.
 - **Restricting Access to Calendars**
@@ -295,7 +326,7 @@ You can use it in front of the Open Web Calendar to configure access and customi
 
 !!! note "Operating System"
 
-    Squid is avaiable for all major platforms.
+    Squid is available for all major platforms.
     For the commands and paths of this tutorial, we assume you run Squid on Debain/Ubuntu.
     The commands might work on other systems, but that is not tested.
 

--- a/docs/host/configure.md
+++ b/docs/host/configure.md
@@ -207,7 +207,11 @@ Recurring events expand into one entry per occurrence, so a small ICS with
 a long RRULE can balloon into millions of events. When the expanded count
 exceeds this cap, the request returns HTTP 413.
 
-This addresses pentest finding CLN-007 (recurring-event denial of service).
+This is a defense-in-depth check that fires after recurring-event expansion
+has already run, so the CPU work of expansion itself is not avoided.
+Operators experiencing CPU pressure should lower `OWC_MAX_SOURCE_EVENTS`,
+which is the true pre-expansion defense. This addresses pentest finding
+CLN-007 (recurring-event denial of service).
 
 ### OWC_MAX_RESPONSE_MB
 

--- a/open_web_calendar/calendars/ics.py
+++ b/open_web_calendar/calendars/ics.py
@@ -12,6 +12,8 @@ import recurring_ical_events
 
 from open_web_calendar.calendars.base import Calendars
 from open_web_calendar.calendars.errors import InvalidCalendars
+from open_web_calendar.config import environment as config
+from open_web_calendar.error import ResponseTooLarge
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -49,6 +51,12 @@ class ICSCalendars(Calendars):
     ) -> list[icalendar.Event]:
         events = []
         for calendar in self._calendars:
+            source_count = sum(1 for _ in calendar.walk("VEVENT"))
+            if source_count > config.max_source_events:
+                raise ResponseTooLarge(
+                    f"Calendar has {source_count} events; "
+                    f"max is {config.max_source_events}."
+                )
             events.extend(recurring_ical_events.of(calendar).between(start, end))
         return events
 

--- a/open_web_calendar/calendars/ics.py
+++ b/open_web_calendar/calendars/ics.py
@@ -51,9 +51,7 @@ class ICSCalendars(Calendars):
     ) -> list[icalendar.Event]:
         # Sum across all parsed calendars so an attacker can't bypass the cap
         # by concatenating multiple VCALENDAR blocks in one response.
-        total_source = sum(
-            1 for calendar in self._calendars for _ in calendar.walk("VEVENT")
-        )
+        total_source = sum(len(calendar.walk("VEVENT")) for calendar in self._calendars)
         if total_source > config.max_source_events:
             raise ResponseTooLarge(
                 f"Calendar has {total_source} events; "

--- a/open_web_calendar/calendars/ics.py
+++ b/open_web_calendar/calendars/ics.py
@@ -52,11 +52,12 @@ class ICSCalendars(Calendars):
         # Sum across all parsed calendars so an attacker can't bypass the cap
         # by concatenating multiple VCALENDAR blocks in one response.
         total_source = sum(len(calendar.walk("VEVENT")) for calendar in self._calendars)
-        if total_source > config.max_source_events:
-            raise ResponseTooLarge(
-                f"Source events ({total_source}) exceed "
-                f"max_source_events ({config.max_source_events})."
-            )
+        ResponseTooLarge.check(
+            "Source events",
+            total_source,
+            "max_source_events",
+            config.max_source_events,
+        )
         events = []
         for calendar in self._calendars:
             events.extend(recurring_ical_events.of(calendar).between(start, end))

--- a/open_web_calendar/calendars/ics.py
+++ b/open_web_calendar/calendars/ics.py
@@ -54,8 +54,8 @@ class ICSCalendars(Calendars):
         total_source = sum(len(calendar.walk("VEVENT")) for calendar in self._calendars)
         if total_source > config.max_source_events:
             raise ResponseTooLarge(
-                f"Calendar has {total_source} events; "
-                f"max is {config.max_source_events}."
+                f"Source events ({total_source}) exceed "
+                f"max_source_events ({config.max_source_events})."
             )
         events = []
         for calendar in self._calendars:

--- a/open_web_calendar/calendars/ics.py
+++ b/open_web_calendar/calendars/ics.py
@@ -49,14 +49,18 @@ class ICSCalendars(Calendars):
     def get_events_between(
         self, start: datetime, end: datetime
     ) -> list[icalendar.Event]:
+        # Sum across all parsed calendars so an attacker can't bypass the cap
+        # by concatenating multiple VCALENDAR blocks in one response.
+        total_source = sum(
+            1 for calendar in self._calendars for _ in calendar.walk("VEVENT")
+        )
+        if total_source > config.max_source_events:
+            raise ResponseTooLarge(
+                f"Calendar has {total_source} events; "
+                f"max is {config.max_source_events}."
+            )
         events = []
         for calendar in self._calendars:
-            source_count = sum(1 for _ in calendar.walk("VEVENT"))
-            if source_count > config.max_source_events:
-                raise ResponseTooLarge(
-                    f"Calendar has {source_count} events; "
-                    f"max is {config.max_source_events}."
-                )
             events.extend(recurring_ical_events.of(calendar).between(start, end))
         return events
 

--- a/open_web_calendar/config.py
+++ b/open_web_calendar/config.py
@@ -121,6 +121,11 @@ class Config:
 
         Variable: OWC_MAX_RESPONSE_EVENTS
         Default: 10000
+
+        Defense-in-depth only: the check fires after recurring_ical_events
+        has already expanded all occurrences, so the CPU work of expansion
+        is not avoided. Real pagination is a future change. Operators with
+        CPU pressure should also lower max_source_events.
         """
         return int(self._source.get("OWC_MAX_RESPONSE_EVENTS", "10000"))
 

--- a/open_web_calendar/config.py
+++ b/open_web_calendar/config.py
@@ -107,6 +107,33 @@ class Config:
         return self._source.get("OWC_ENABLE_JS", "true").lower() != "false"
 
     @config_property
+    def max_source_events(self) -> int:
+        """Maximum VEVENTs accepted in a single source calendar.
+
+        Variable: OWC_MAX_SOURCE_EVENTS
+        Default: 1000
+        """
+        return int(self._source.get("OWC_MAX_SOURCE_EVENTS", "1000"))
+
+    @config_property
+    def max_response_events(self) -> int:
+        """Maximum expanded events in a /calendar.events.json response.
+
+        Variable: OWC_MAX_RESPONSE_EVENTS
+        Default: 10000
+        """
+        return int(self._source.get("OWC_MAX_RESPONSE_EVENTS", "10000"))
+
+    @config_property
+    def max_response_bytes(self) -> int:
+        """Maximum byte size of a /calendar.events.json response body.
+
+        Variable: OWC_MAX_RESPONSE_MB
+        Default: 10 (MB)
+        """
+        return int(float(self._source.get("OWC_MAX_RESPONSE_MB", "10")) * MB)
+
+    @config_property
     def cache_expire_after(self) -> int:
         """The cache expiration timeout in seconds.
 

--- a/open_web_calendar/config.py
+++ b/open_web_calendar/config.py
@@ -108,7 +108,10 @@ class Config:
 
     @config_property
     def max_source_events(self) -> int:
-        """Maximum VEVENTs accepted in a single source calendar.
+        """Maximum VEVENTs accepted from a single ICS payload.
+
+        The cap sums across all VCALENDAR blocks in one fetched ICS response,
+        so an attacker can't bypass it by concatenating multiple calendars.
 
         Variable: OWC_MAX_SOURCE_EVENTS
         Default: 1000
@@ -135,6 +138,10 @@ class Config:
 
         Variable: OWC_MAX_RESPONSE_MB
         Default: 10 (MB)
+
+        The check runs after the full JSON has been serialized in memory,
+        so an extreme response transiently allocates the full size before
+        rejection. Real streaming serialization is a future change.
         """
         return int(float(self._source.get("OWC_MAX_RESPONSE_MB", "10")) * MB)
 

--- a/open_web_calendar/convert/base.py
+++ b/open_web_calendar/convert/base.py
@@ -25,6 +25,7 @@ from open_web_calendar.calendars import (
 )
 from open_web_calendar.clean_html import clean_html
 from open_web_calendar.encryption import EmptyFernetStore, FernetStore
+from open_web_calendar.error import ResponseTooLarge
 
 
 def get_text_from_url(url):
@@ -130,6 +131,8 @@ class ConversionStrategy:
             index, url = index_url
             calendars = self.get_calendars_from_url(url)
             self.collect_components_from(index, calendars)
+        except ResponseTooLarge:
+            raise
         except:
             ty, err, tb = sys.exc_info()
             component = self.error(ty, err, tb, url)

--- a/open_web_calendar/convert/base.py
+++ b/open_web_calendar/convert/base.py
@@ -132,6 +132,7 @@ class ConversionStrategy:
             calendars = self.get_calendars_from_url(url)
             self.collect_components_from(index, calendars)
         except ResponseTooLarge:
+            # CLN-007 caps must surface as HTTP 413, not as an in-band error event.
             raise
         except:
             ty, err, tb = sys.exc_info()

--- a/open_web_calendar/convert/events.py
+++ b/open_web_calendar/convert/events.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import datetime
-import json
 import zoneinfo
 from html import escape
 from typing import TYPE_CHECKING, Any
@@ -215,13 +214,14 @@ class ConvertToEvents(ConversionStrategy):
         return self.clean_html(description.html or description.text)
 
     def merge(self):
-        body = json.dumps(self.components).encode("utf-8")
-        if len(body) > config.max_response_bytes:
+        response = jsonify(self.components)
+        body_size = len(response.get_data())
+        if body_size > config.max_response_bytes:
             raise ResponseTooLarge(
-                f"Response would be {len(body)} bytes; "
+                f"Response would be {body_size} bytes; "
                 f"max is {config.max_response_bytes}."
             )
-        return jsonify(self.components)
+        return response
 
     def collect_components_from(self, calendar_index: int, calendars: Calendars):
         # see https://stackoverflow.com/a/16115575/1320237

--- a/open_web_calendar/convert/events.py
+++ b/open_web_calendar/convert/events.py
@@ -216,27 +216,30 @@ class ConvertToEvents(ConversionStrategy):
     def merge(self):
         if len(self.components) > config.max_response_events:
             raise ResponseTooLarge(
-                f"Response would have {len(self.components)} events; "
-                f"max is {config.max_response_events}."
+                f"Response has {len(self.components)} events; "
+                f"max_response_events is {config.max_response_events}."
             )
         response = jsonify(self.components)
-        body_size = len(response.get_data())
-        if body_size > config.max_response_bytes:
+        # calculate_content_length() reads the cached body size without
+        # forcing a second buffer copy via get_data().
+        body_size = response.calculate_content_length()
+        if body_size is not None and body_size > config.max_response_bytes:
             raise ResponseTooLarge(
-                f"Response would be {body_size} bytes; "
-                f"max is {config.max_response_bytes}."
+                f"Response is {body_size} bytes; "
+                f"max_response_bytes is {config.max_response_bytes}."
             )
         return response
 
     def collect_components_from(self, calendar_index: int, calendars: Calendars):
         # see https://stackoverflow.com/a/16115575/1320237
         events = calendars.get_events_between(self.from_date, self.to_date)
-        if len(events) > config.max_response_events:
-            raise ResponseTooLarge(
-                f"Calendar would generate {len(events)} events; "
-                f"max is {config.max_response_events}."
-            )
         with self.lock:
+            total = len(self.components) + len(events)
+            if total > config.max_response_events:
+                raise ResponseTooLarge(
+                    f"Expanded events ({total}) exceed "
+                    f"max_response_events ({config.max_response_events})."
+                )
             for event in events:
                 json_event = self.convert_ical_event(calendar_index, event)
                 self.components.append(json_event)

--- a/open_web_calendar/convert/events.py
+++ b/open_web_calendar/convert/events.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import zoneinfo
 from html import escape
 from typing import TYPE_CHECKING, Any
@@ -14,6 +15,9 @@ from urllib.parse import unquote
 from dateutil.parser import parse as parse_date
 from flask import jsonify
 from icalendar_compatibility import Description, Location, LocationSpec
+
+from open_web_calendar.config import environment as config
+from open_web_calendar.error import ResponseTooLarge
 
 from .base import ConversionStrategy
 
@@ -211,11 +215,22 @@ class ConvertToEvents(ConversionStrategy):
         return self.clean_html(description.html or description.text)
 
     def merge(self):
+        body = json.dumps(self.components).encode("utf-8")
+        if len(body) > config.max_response_bytes:
+            raise ResponseTooLarge(
+                f"Response would be {len(body)} bytes; "
+                f"max is {config.max_response_bytes}."
+            )
         return jsonify(self.components)
 
     def collect_components_from(self, calendar_index: int, calendars: Calendars):
         # see https://stackoverflow.com/a/16115575/1320237
         events = calendars.get_events_between(self.from_date, self.to_date)
+        if len(events) > config.max_response_events:
+            raise ResponseTooLarge(
+                f"Calendar would generate {len(events)} events; "
+                f"max is {config.max_response_events}."
+            )
         with self.lock:
             for event in events:
                 json_event = self.convert_ical_event(calendar_index, event)

--- a/open_web_calendar/convert/events.py
+++ b/open_web_calendar/convert/events.py
@@ -214,6 +214,11 @@ class ConvertToEvents(ConversionStrategy):
         return self.clean_html(description.html or description.text)
 
     def merge(self):
+        if len(self.components) > config.max_response_events:
+            raise ResponseTooLarge(
+                f"Response would have {len(self.components)} events; "
+                f"max is {config.max_response_events}."
+            )
         response = jsonify(self.components)
         body_size = len(response.get_data())
         if body_size > config.max_response_bytes:

--- a/open_web_calendar/convert/events.py
+++ b/open_web_calendar/convert/events.py
@@ -214,19 +214,16 @@ class ConvertToEvents(ConversionStrategy):
         return self.clean_html(description.html or description.text)
 
     def merge(self):
-        if len(self.components) > config.max_response_events:
-            raise ResponseTooLarge(
-                f"Response has {len(self.components)} events; "
-                f"max_response_events is {config.max_response_events}."
-            )
         response = jsonify(self.components)
         # calculate_content_length() reads the cached body size without
         # forcing a second buffer copy via get_data().
         body_size = response.calculate_content_length()
-        if body_size is not None and body_size > config.max_response_bytes:
-            raise ResponseTooLarge(
-                f"Response is {body_size} bytes; "
-                f"max_response_bytes is {config.max_response_bytes}."
+        if body_size is not None:
+            ResponseTooLarge.check(
+                "Response bytes",
+                body_size,
+                "max_response_bytes",
+                config.max_response_bytes,
             )
         return response
 
@@ -235,11 +232,12 @@ class ConvertToEvents(ConversionStrategy):
         events = calendars.get_events_between(self.from_date, self.to_date)
         with self.lock:
             total = len(self.components) + len(events)
-            if total > config.max_response_events:
-                raise ResponseTooLarge(
-                    f"Expanded events ({total}) exceed "
-                    f"max_response_events ({config.max_response_events})."
-                )
+            ResponseTooLarge.check(
+                "Expanded events",
+                total,
+                "max_response_events",
+                config.max_response_events,
+            )
             for event in events:
                 json_event = self.convert_ical_event(calendar_index, event)
                 self.components.append(json_event)

--- a/open_web_calendar/error.py
+++ b/open_web_calendar/error.py
@@ -17,6 +17,12 @@ if TYPE_CHECKING:
     from types import TracebackType
 
 
+class ResponseTooLarge(Exception):
+    """Raised when an events.json response exceeds configured caps (CLN-007)."""
+
+    http_status_code = 413
+
+
 def http_status_code_for_error(error: Exception) -> int:
     """Return the status code from an exception or 500."""
     return getattr(error, "http_status_code", 500)
@@ -71,4 +77,9 @@ def convert_error_message_to_json(
     }
 
 
-__all__ = ["convert_error_message_to_json", "http_status_code_for_error", "json_error"]
+__all__ = [
+    "ResponseTooLarge",
+    "convert_error_message_to_json",
+    "http_status_code_for_error",
+    "json_error",
+]

--- a/open_web_calendar/error.py
+++ b/open_web_calendar/error.py
@@ -22,6 +22,12 @@ class ResponseTooLarge(Exception):
 
     http_status_code = 413
 
+    @classmethod
+    def check(cls, label: str, value: int, cap_name: str, cap: int) -> None:
+        """Raise if value > cap, naming the cap in the error message."""
+        if value > cap:
+            raise cls(f"{label} ({value}) exceed {cap_name} ({cap}).")
+
 
 def http_status_code_for_error(error: Exception) -> int:
     """Return the status code from an exception or 500."""

--- a/open_web_calendar/test/test_cln_007_recurring_events_dos.py
+++ b/open_web_calendar/test/test_cln_007_recurring_events_dos.py
@@ -146,3 +146,26 @@ def test_cap_rejection_has_413_status_and_json_body(client, cache_url):
     assert response.status_code == 413
     assert response.content_type.startswith("application/json")
     assert response.json["code"] == 413
+
+
+def test_response_bytes_cap_is_enforced(client, cache_url, monkeypatch):
+    """Lowering OWC_MAX_RESPONSE_MB rejects an otherwise-passing calendar."""
+    monkeypatch.setitem(os.environ, "OWC_MAX_RESPONSE_MB", "0.001")
+    url = "http://example.com/byte-cap.ics"
+    cache_url(url, _build_simple_calendar(event_count=50))
+    response = client.get(
+        f"/calendar.events.json?url={url}&from=2026-01-01&to=2026-02-01"
+    )
+    assert response.status_code == 413
+
+
+def test_source_cap_sums_across_concatenated_calendars(client, cache_url):
+    """Splitting events across multiple VCALENDAR blocks must not bypass the cap."""
+    url = "http://example.com/multi-cal.ics"
+    # Two concatenated calendars, each with 600 events: 1200 > default cap 1000.
+    half = _build_simple_calendar(event_count=600)
+    cache_url(url, half + half)
+    response = client.get(
+        f"/calendar.events.json?url={url}&from=2026-01-01&to=2026-02-01"
+    )
+    assert response.status_code == 413

--- a/open_web_calendar/test/test_cln_007_recurring_events_dos.py
+++ b/open_web_calendar/test/test_cln_007_recurring_events_dos.py
@@ -82,13 +82,13 @@ def test_default_allows_normal_recurring_calendar(client, cache_url):
 def test_pentest_poc_is_rejected(client, cache_url):
     """A scaled-down CLN-007 pentest pattern is rejected by the expanded cap.
 
-    Real PoC uses 100 source events; we use 5 to keep CI time bounded while
-    still triggering >10000 expanded events from daily-until-2050 RRULEs.
+    Real PoC uses 100 source events; we use 5 over a 6-year window which still
+    expands to ~10960 events (over the OWC_MAX_RESPONSE_EVENTS cap of 10000).
     """
     url = "http://example.com/poc.ics"
     cache_url(url, _build_pentest_poc(source_event_count=5))
     response = client.get(
-        f"/calendar.events.json?url={url}&from=2025-01-01&to=2027-01-01"
+        f"/calendar.events.json?url={url}&from=2020-01-01&to=2026-01-01"
     )
     assert response.status_code == 413
 

--- a/open_web_calendar/test/test_cln_007_recurring_events_dos.py
+++ b/open_web_calendar/test/test_cln_007_recurring_events_dos.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+"""Hard caps on /calendar.events.json prevent recurring-event DoS.
+
+Addresses pentest finding CLN-007. A malicious 20KB ICS with daily
+recurring events until 2050 expands to ~1.69 million events (~2.4GB
+JSON), stalling a worker until timeout.
+
+This module verifies three layers of defense:
+- OWC_MAX_SOURCE_EVENTS: cap on raw VEVENT count per source calendar
+- OWC_MAX_RESPONSE_EVENTS: cap on expanded events per response
+- OWC_MAX_RESPONSE_MB: cap on serialized JSON byte size
+
+Each cap returns HTTP 413 when exceeded.
+"""
+
+import os
+
+
+def _build_calendar(events_body: str) -> str:
+    return f"BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:test\r\n{events_body}END:VCALENDAR\r\n"
+
+
+def _build_pentest_poc(source_event_count: int = 100) -> str:
+    """Return the pentest CLN-007 PoC: N events each with daily RRULE to 2050."""
+    body = ""
+    for i in range(source_event_count):
+        body += (
+            "BEGIN:VEVENT\r\n"
+            "DTSTAMP:20151219T021727Z\r\n"
+            "DTSTART:20200101T100000Z\r\n"
+            "DTEND:20200101T110000Z\r\n"
+            "RRULE:FREQ=DAILY;UNTIL=20500310T035959Z\r\n"
+            "SUMMARY:Meeting\r\n"
+            f"UID:{i + 1}@test\r\n"
+            "END:VEVENT\r\n"
+        )
+    return _build_calendar(body)
+
+
+def _build_simple_calendar(event_count: int) -> str:
+    """Return a calendar with N simple non-recurring events."""
+    body = ""
+    for i in range(event_count):
+        body += (
+            "BEGIN:VEVENT\r\n"
+            "DTSTAMP:20260101T000000Z\r\n"
+            f"DTSTART:202601{(i % 28) + 1:02d}T100000Z\r\n"
+            f"DTEND:202601{(i % 28) + 1:02d}T110000Z\r\n"
+            "SUMMARY:Simple Event\r\n"
+            f"UID:simple-{i}@test\r\n"
+            "END:VEVENT\r\n"
+        )
+    return _build_calendar(body)
+
+
+def test_default_allows_normal_recurring_calendar(client, cache_url):
+    """A small recurring calendar within default caps returns events."""
+    url = "http://example.com/normal.ics"
+    body = ""
+    for i in range(5):
+        body += (
+            "BEGIN:VEVENT\r\n"
+            "DTSTAMP:20260101T000000Z\r\n"
+            "DTSTART:20260101T100000Z\r\n"
+            "DTEND:20260101T110000Z\r\n"
+            "RRULE:FREQ=DAILY;COUNT=30\r\n"
+            "SUMMARY:Daily Standup\r\n"
+            f"UID:normal-{i}@test\r\n"
+            "END:VEVENT\r\n"
+        )
+    cache_url(url, _build_calendar(body))
+    response = client.get(
+        f"/calendar.events.json?url={url}&from=2026-01-01&to=2026-02-01"
+    )
+    assert response.status_code == 200
+    assert len(response.json) > 0
+
+
+def test_pentest_poc_is_rejected(client, cache_url):
+    """A scaled-down CLN-007 pentest pattern is rejected by the expanded cap.
+
+    Real PoC uses 100 source events; we use 5 to keep CI time bounded while
+    still triggering >10000 expanded events from daily-until-2050 RRULEs.
+    """
+    url = "http://example.com/poc.ics"
+    cache_url(url, _build_pentest_poc(source_event_count=5))
+    response = client.get(
+        f"/calendar.events.json?url={url}&from=2025-01-01&to=2027-01-01"
+    )
+    assert response.status_code == 413
+
+
+def test_too_many_source_events_is_rejected(client, cache_url):
+    """A calendar exceeding OWC_MAX_SOURCE_EVENTS is rejected pre-expansion."""
+    url = "http://example.com/many-source.ics"
+    cache_url(url, _build_simple_calendar(event_count=2000))
+    response = client.get(
+        f"/calendar.events.json?url={url}&from=2026-01-01&to=2026-02-01"
+    )
+    assert response.status_code == 413
+
+
+def test_too_many_expanded_events_is_rejected(client, cache_url):
+    """A single event whose RRULE expands beyond the cap is rejected."""
+    url = "http://example.com/expand-bomb.ics"
+    # DAILY with COUNT=20000 produces ~20k occurrences within a 60-year window,
+    # which exceeds the default OWC_MAX_RESPONSE_EVENTS=10000 cap.
+    body = (
+        "BEGIN:VEVENT\r\n"
+        "DTSTAMP:20260101T000000Z\r\n"
+        "DTSTART:20000101T100000Z\r\n"
+        "DTEND:20000101T110000Z\r\n"
+        "RRULE:FREQ=DAILY;COUNT=20000\r\n"
+        "SUMMARY:Daily 20k times\r\n"
+        "UID:expand-bomb@test\r\n"
+        "END:VEVENT\r\n"
+    )
+    cache_url(url, _build_calendar(body))
+    response = client.get(
+        f"/calendar.events.json?url={url}&from=2000-01-01&to=2060-01-01"
+    )
+    assert response.status_code == 413
+
+
+def test_caps_are_tunable_via_env_vars(client, cache_url, monkeypatch):
+    """Raising OWC_MAX_SOURCE_EVENTS lets a previously-rejected calendar through."""
+    monkeypatch.setitem(os.environ, "OWC_MAX_SOURCE_EVENTS", "10000")
+    url = "http://example.com/raised-cap.ics"
+    cache_url(url, _build_simple_calendar(event_count=2000))
+    response = client.get(
+        f"/calendar.events.json?url={url}&from=2026-01-01&to=2026-02-01"
+    )
+    assert response.status_code == 200
+
+
+def test_cap_rejection_has_413_status_and_json_body(client, cache_url):
+    """A rejected request returns 413 with the standard JSON error shape."""
+    url = "http://example.com/too-big.ics"
+    cache_url(url, _build_simple_calendar(event_count=2000))
+    response = client.get(
+        f"/calendar.events.json?url={url}&from=2026-01-01&to=2026-02-01"
+    )
+    assert response.status_code == 413
+    assert response.content_type.startswith("application/json")
+    assert response.json["code"] == 413


### PR DESCRIPTION
Addresses pentest finding CLN-007.

A malicious ICS with daily-until-2050 RRULEs expands to millions of events (gigabytes of JSON), stalling a worker until timeout. This PR adds three tunable caps: `OWC_MAX_SOURCE_EVENTS` (1000, pre-expansion), `OWC_MAX_RESPONSE_EVENTS` (10000, post-expansion), `OWC_MAX_RESPONSE_MB` (10, post-serialization). Exceeding any cap returns HTTP 413. Full pagination (the pentest's primary recommendation) is deferred; this PR ships hard caps as defense-in-depth.

See also: #595.
