### PR TITLE
docs: contribution workflow, code of conduct, issue and PR templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+# CODEOWNERS for automatic PR review assignment.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @niccokunzmann

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Something is not working as expected
+title: '[Bug] '
+labels: ''
+assignees: ''
+---
+
+<!-- Fill in what you can. Not every section will apply to every bug. -->
+
+## Describe the bug
+
+<!-- A short description of what is wrong. -->
+
+## To reproduce
+
+<!-- Steps to reproduce. Include the calendar URL and any specification parameters you set. -->
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What you expected to happen. -->
+
+## Screenshots or `.ics` sample
+
+<!-- If the bug involves a specific event or calendar, attach the .ics file. -->
+
+## Environment
+
+- [ ] Where you ran into the bug: [hosted instance](https://open-web-calendar.hosted.quelltext.eu) / self-hosted / Docker
+- [ ] Browser:           <!-- e.g. Firefox 138, Chrome 126, Safari 17 -->
+- [ ] Operating system:  <!-- e.g. Ubuntu 24, macOS 14, Windows 11, Android 14 -->
+- [ ] Calendar source:   <!-- e.g. Nextcloud CalDAV, plain .ics URL, ICS feed from another service -->
+
+## Additional context
+
+<!-- Anything else that helps explain the bug: related issues, console errors, network logs. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,10 +30,10 @@ assignees: ''
 
 ## Environment
 
-- [ ] Where you ran into the bug: [hosted instance](https://open-web-calendar.hosted.quelltext.eu) / self-hosted / Docker
-- [ ] Browser:           <!-- e.g. Firefox 138, Chrome 126, Safari 17 -->
-- [ ] Operating system:  <!-- e.g. Ubuntu 24, macOS 14, Windows 11, Android 14 -->
-- [ ] Calendar source:   <!-- e.g. Nextcloud CalDAV, plain .ics URL, ICS feed from another service -->
+- Where you ran into the bug: [hosted instance](https://open-web-calendar.hosted.quelltext.eu) / self-hosted / Docker
+- Browser:           <!-- e.g. Firefox 138, Chrome 126, Safari 17 -->
+- Operating system:  <!-- e.g. Ubuntu 24, macOS 14, Windows 11, Android 14 -->
+- Calendar source:   <!-- e.g. Nextcloud CalDAV, plain .ics URL, ICS feed from another service -->
 
 ## Additional context
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: GPL-2.0-only
+
+blank_issues_enabled: true
+contact_links:
+  - name: Discussions
+    url: https://github.com/niccokunzmann/open-web-calendar/discussions
+    about: For questions, ideas, and general conversation. Not for bug reports.
+  - name: Security issues
+    url: https://github.com/niccokunzmann/open-web-calendar/security/advisories/new
+    about: Report a security vulnerability privately. See SECURITY.md for details.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: '[Feature] '
+labels: ''
+assignees: ''
+---
+
+## What you want
+
+<!-- A short description of the feature or change. -->
+
+## Why
+
+<!-- The problem it solves or the use case it enables. Real examples help. -->
+
+## How you imagine it working
+
+<!-- A rough sketch is fine. Screenshots, mockups, or example configurations welcome. -->
+
+## Alternatives you've considered
+
+<!-- Other ways to solve the same problem, and why this one is preferable. -->
+
+## Additional context
+
+<!-- Related issues, links to similar features in other tools, anything else useful. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!--
+SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+## Closes issue
+
+<!-- Replace ISSUE_NUMBER with the issue this PR fixes so GitHub auto-closes it on merge. -->
+
+- [ ] Closes #ISSUE_NUMBER
+
+## Description
+
+<!-- What changed and why. Keep it short. Link to any related discussion. -->
+
+## Checklist
+
+- [ ] Tests pass locally (`tox -e py` for unit, `tox -e web` for browser tests if relevant).
+- [ ] Lint passes (`tox -e ruff`) and any new files have SPDX headers (`tox -e reuse`).
+- [ ] Docs updated if behavior changed.
+- [ ] Changelog entry added to `docs/changelog.md` if user-facing.
+- [ ] If you used AI to draft any part of this PR, you have followed the
+  [PCE AI policy](https://pycal.org/ai-policy/) (disclose the model and how
+  you used it, take responsibility for the output, respond to feedback).
+
+## Additional information
+
+<!-- Screenshots, .ics samples, links to related issues, or anything else useful for review. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,9 +6,9 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 ## Closes issue
 
-<!-- Replace ISSUE_NUMBER with the issue this PR fixes so GitHub auto-closes it on merge. -->
+<!-- Replace with the issue number, e.g. "Closes #123". One line per issue if more than one. -->
 
-- [ ] Closes #ISSUE_NUMBER
+Closes #
 
 ## Description
 
@@ -19,7 +19,6 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 - [ ] Tests pass locally (`tox -e py` for unit, `tox -e web` for browser tests if relevant).
 - [ ] Lint passes (`tox -e ruff`) and any new files have SPDX headers (`tox -e reuse`).
 - [ ] Docs updated if behavior changed.
-- [ ] Changelog entry added to `docs/changelog.md` if user-facing.
 - [ ] If you used AI to draft any part of this PR, you have followed the
   [PCE AI policy](https://pycal.org/ai-policy/) (disclose the model and how
   you used it, take responsibility for the output, respond to feedback).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ Closes #
 - [ ] Tests pass locally (`tox -e py` for unit, `tox -e web` for browser tests if relevant).
 - [ ] Lint passes (`tox -e ruff`) and any new files have SPDX headers (`tox -e reuse`).
 - [ ] Docs updated if behavior changed.
+- [ ] Changelog entry added to `docs/changelog.md` if user-facing.
 - [ ] If you used AI to draft any part of this PR, you have followed the
   [PCE AI policy](https://pycal.org/ai-policy/) (disclose the model and how
   you used it, take responsibility for the output, respond to feedback).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Contributor Covenant 3.0 Code of Conduct
+
+The Open Web Calendar project follows the Contributor Covenant 3.0 Code of Conduct, which is hosted on the Python Calendaring Ecosystem website at the following link.
+
+<https://pycal.org/code-of-conduct/>

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -36,3 +36,9 @@ path = "open_web_calendar/static/css/dhtmlx/dhtmlxscheduler_material/fonts.googl
 precedence = "aggregate"
 SPDX-FileCopyrightText = "Christian Robertson <https://fonts.google.com/specimen/Roboto/about> <https://github.com/googlefonts/roboto>"
 SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = ".github/ISSUE_TEMPLATE/**.md"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>"
+SPDX-License-Identifier = "CC-BY-SA-4.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 2024 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+# SPDX-FileCopyrightText: 2024 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
 #
 # SPDX-License-Identifier: GPL-2.0-only
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,9 @@ The latest version might not be released, yet.
 
 - Add development guide links 
 - Add CLI help implementation for better developer onboarding, see [Pull Request #981](https://github.com/niccokunzmann/open-web-calendar/pull/981) by [@Stazz0](https://github.com/Stazz0)
+- Add browser and unit testing guides, complete the debug mode section, and expand the translation guide, see [Issue 1115](https://github.com/niccokunzmann/open-web-calendar/issues/1115) and [Issue 987](https://github.com/niccokunzmann/open-web-calendar/issues/987)
+- Fix broken links in `docs/contributing.md` so they work in GitHub's blob view, see [Issue 834](https://github.com/niccokunzmann/open-web-calendar/issues/834)
+- Add `CODE_OF_CONDUCT.md`, `CODEOWNERS`, pull request template, and bug, feature, and config issue templates, see [Pull Request #1208](https://github.com/niccokunzmann/open-web-calendar/pull/1208)
 
 ## v1.51
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -10,34 +10,34 @@ description: "You can improve the project yourself. Get started here."
 # Contribute ♥️
 
 [![Sponsor with GitHub](https://img.shields.io/github/sponsors/niccokunzmann?logo=github&label=GitHub%20Sponsors
-)]({{link.fund.github_sponsors}})
-[![Support on Open Collective](https://img.shields.io/opencollective/all/open-web-calendar?label=support%20on%20open%20collective)]({{link.fund.open_collective}})
+)](https://github.com/sponsors/niccokunzmann)
+[![Support on Open Collective](https://img.shields.io/opencollective/all/open-web-calendar?label=support%20on%20open%20collective)](https://opencollective.com/open-web-calendar/)
 
 There are several ways in which you can help this project:
 
-- [Use it]({{link.web}}) and [report errors]({{link.issues}})
-- [Set up your development environment](../dev/)
-- [Fund costs - Open Collective]({{link.fund.open_collective}})
-- [Fund sustainability - GitHub Sponsors]({{link.fund.github_sponsors}})
-- [Translate this project to your language](../dev/translate)
-- Have a look at [open issues]({{link.issues}}) e.g. those especially to get started, labeled [good first issue]({{link.good_first_issue}}), leave a note and work on it.
-- If you customized a calendar, please consider [contributing it as a template](../templates) for others to use.
+- [Use it](https://open-web-calendar.hosted.quelltext.eu) and [report errors](https://github.com/niccokunzmann/open-web-calendar/issues)
+- [Set up your development environment](https://open-web-calendar.quelltext.eu/dev/)
+- [Fund costs - Open Collective](https://opencollective.com/open-web-calendar/)
+- [Fund sustainability - GitHub Sponsors](https://github.com/sponsors/niccokunzmann)
+- [Translate this project to your language](https://open-web-calendar.quelltext.eu/dev/translate/)
+- Have a look at [open issues](https://github.com/niccokunzmann/open-web-calendar/issues) e.g. those especially to get started, labeled [good first issue](https://github.com/niccokunzmann/open-web-calendar/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), leave a note and work on it.
+- If you customized a calendar, please consider [contributing it as a template](https://open-web-calendar.quelltext.eu/templates/) for others to use.
 
 ## Ways to Contribute
 
 ### 🐛 Report Bugs
-Found a bug? Please [create an issue]({{link.issues}}) with:
+Found a bug? Please [create an issue](https://github.com/niccokunzmann/open-web-calendar/issues) with:
 - Clear description of the problem
 - Steps to reproduce
 - Expected vs actual behavior
 
 ### 💡 Suggest Features
-Have an idea? [Open an issue]({{link.issues}}) to discuss it!
+Have an idea? [Open an issue](https://github.com/niccokunzmann/open-web-calendar/issues) to discuss it!
 
 ### 🔧 Code Contributions
 1. **Fork the repository**
 2. **Create a feature branch**: `git checkout -b feature/your-feature-name`
-3. **Set up development environment**: See [development documentation](../dev/)
+3. **Set up development environment**: See [development documentation](https://open-web-calendar.quelltext.eu/dev/)
 4. **Make your changes**
 5. **Run tests**
 6. **Submit a pull request**
@@ -47,9 +47,17 @@ Help improve our documentation by:
 - Fixing typos or unclear instructions
 - Adding examples
 
+## Community Standards
+
+This project is part of the Python Calendaring Ecosystem (PCE) and follows
+its shared standards:
+
+- [Code of Conduct](https://pycal.org/code-of-conduct/): how we expect contributors to treat each other.
+- [AI policy](https://pycal.org/ai-policy/): how to disclose AI use when contributing.
+
 ## Get Help
 
-Questions? Check our [documentation]({{link.web}}) or join the [discussions](https://github.com/niccokunzmann/open-web-calendar/discussions).
+Questions? Check our [documentation](https://open-web-calendar.quelltext.eu/) or join the [discussions](https://github.com/niccokunzmann/open-web-calendar/discussions).
 
 If you are part of a company depending on the Open Web Calendar,
 please contact Nicco Kunzmann, the maintainer:

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -12,6 +12,25 @@ description: "Learn how to develop the Open Web Calendar."
 This section guides you through everything you need to know to develop the
 software: build it and make changes.
 
+## First-time Contributors
+
+Contributions from people new to the Open Web Calendar are welcome.
+A few things worth knowing before you start:
+
+- You are free to pick up any open issue. Comment on it to say you are
+  starting, and open a draft pull request when you have something to show.
+- Open the PR early. It saves other people from duplicating your effort and
+  gives reviewers a chance to weigh in before you go too far.
+- Ask questions if the scope is unclear. Better to clarify on the issue
+  than to rebuild after a review.
+- The [`good first issue`](https://github.com/niccokunzmann/open-web-calendar/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+  label is a good place to start if you are looking for something small.
+
+If you use AI to help write a pull request, follow the
+[PCE AI policy](https://pycal.org/ai-policy/). The short version: take
+responsibility for what you submit, disclose the model and how you used it
+in your commit messages, and be ready to discuss the code.
+
 ## Clone the Repository
 
 ```sh
@@ -83,13 +102,29 @@ You can also change the layout of the window to test the responsive design:
 tox -e web -- -D window=375x812 # iPhone11 size
 ```
 
+When a browser test fails, the runner saves a screenshot of the page so you can
+see what the browser actually saw at the moment of failure.
+The screenshots land in the `screenshots/` folder at the project root,
+named after the feature and the line that failed
+(for example, `issue-679-caldav-sign-up@line-7.png`).
+Behave also prints the path and line of the failing step in `<file>:<line>`
+form, which most modern terminals (VS Code, iTerm2, Windows Terminal) turn
+into a clickable link to the source.
+
+For details on writing browser tests, see the
+[browser testing guide](testing.md).
+
 ### Debug Mode
 
-In case the browser tests fail, screenshots are recorded and a link is printed.
+To run the app locally with debug mode on, use:
 
 ```sh
-
+tox -e dev
 ```
+
+This starts the Flask dev server on <http://localhost:5000> with `APP_DEBUG=true`
+and a test encryption key. The full list of environment variables it sets is
+in `tox.ini` under `[testenv:dev]`.
 
 ## Documentation
 
@@ -109,3 +144,23 @@ tox -e docs-quick -- serve
 We are using [mkdocs] with the [material theme](https://squidfunk.github.io/mkdocs-material/).
 
 [mkdocs]: https://www.mkdocs.org
+
+## Troubleshooting
+
+A few things that tend to trip people up:
+
+- **Browser tests can't find Firefox.** Install Firefox locally, or pass
+  `-D browser=chrome` (you need a real Chrome install for that too). Selenium
+  drives the browser of your choice; we don't ship one.
+- **Docs build fails on Windows with `FileNotFoundError: ...\translations\de`.**
+  The `translations` entry in the repo root is a symlink that Windows checks
+  out as a plain file unless symlinks are enabled. Replace it with a directory
+  symlink locally (`mklink /D translations open_web_calendar\translations`).
+  Do not commit the change.
+- **`tox -e reuse` flags missing SPDX headers.** Every new source file needs
+  the SPDX header at the top (copyright line + license identifier). Copy it
+  from any existing file of the same type.
+- **The docs build writes changes to `.po` files.** Those are translation
+  templates regenerated from your source edits. They get synced separately by
+  the maintainers' translation workflow, so don't commit them as part of an
+  unrelated PR.

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -107,9 +107,12 @@ see what the browser actually saw at the moment of failure.
 The screenshots land in the `screenshots/` folder at the project root,
 named after the feature and the line that failed
 (for example, `issue-679-caldav-sign-up@line-7.png`).
-Behave also prints the path and line of the failing step in `<file>:<line>`
-form, which most modern terminals (VS Code, iTerm2, Windows Terminal) turn
-into a clickable link to the source.
+The runner prints the full path as `Capturing screenshot to <path>` so you
+can open it directly from the terminal.
+
+Behave's own output lists each step with its source location as `<file>:<line>`.
+Most modern terminals (VS Code, iTerm2, Windows Terminal) turn these into
+clickable links that jump to the failing step in the source.
 
 For details on writing browser tests, see the
 [browser testing guide](testing.md).

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,0 +1,89 @@
+---
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+comments: true
+description: "Write and run browser tests for the Open Web Calendar."
+---
+
+# Browser Tests
+
+Bug fixes that affect the user-facing interface usually ship with a regression test.
+We use [Behave] with Selenium to drive a real browser against a live Flask app.
+The suite lives in `open_web_calendar/features/`.
+
+If you have not run the browser tests before, start with the
+[browser testing section](index.md#browser-testing) in the setup guide.
+It covers `tox -e web`, picking a browser, and changing the window size.
+
+## Where things live
+
+- `open_web_calendar/features/*.feature`: the Gherkin scenarios.
+- `open_web_calendar/features/calendars/`: the `.ics` fixtures the scenarios
+  load. A small HTTP server in `environment.py` serves these to the browser.
+- `open_web_calendar/features/steps/browser_steps.py`: the reusable
+  `@given`/`@when`/`@then` step library. Check it before writing a new step.
+- `open_web_calendar/features/environment.py`: the setup that boots the
+  Flask app, the Selenium driver, and the fixture HTTP server.
+
+## Run one feature
+
+```sh
+tox -e web -- open_web_calendar/features/issue-679-caldav-sign-up.feature
+```
+
+You can pass any Behave options after the `--`. For example, run a single
+scenario by line number:
+
+```sh
+tox -e web -- open_web_calendar/features/issue-679-caldav-sign-up.feature:10
+```
+
+## Add a feature for a bug
+
+Name the file after the issue it covers: `issue-<number>-<short-slug>.feature`.
+Most regression tests follow this pattern, so the regression for issue 1234
+becomes `issue-1234-short-description.feature`. Topic-named features
+(`burger-menu.feature`, `categories.feature`, etc.) also exist for behavior
+that is not tied to one bug.
+
+A small feature looks like this:
+
+```gherkin
+Feature: We do not show the sign-up button on regular events.
+
+    Scenario: Usually, I cannot see the signup button.
+        Given we add the calendar "issue-23-location-berlin"
+         When we look at 2025-01-10
+          And we click on the event "Event in Berlin!"
+         Then we cannot see the text "Sign Up"
+```
+
+The `Given we add the calendar "..."` step takes the fixture name without
+the `.ics` extension. The fixture HTTP server picks it up automatically.
+
+## Add a fixture calendar
+
+Drop the `.ics` file into `open_web_calendar/features/calendars/` and
+reference its stem from the scenario. No registration step needed.
+
+Keep fixtures small. One event is enough for most tests.
+If the bug involves a specific date, pin the event to that date and
+use `When we look at <date>` to make the scenario deterministic.
+
+## Add a step
+
+Before writing a new step, search [browser_steps.py] for an existing one
+that covers the assertion.
+
+If none fits, add a function to `browser_steps.py` decorated with `@given`,
+`@when`, or `@then`. Keep the wording natural so other scenarios can reuse it.
+
+## When a test fails
+
+See [Browser Testing](index.md#browser-testing) for where screenshots land
+and how to jump from a failed step back to its source line.
+
+[Behave]: https://behave.readthedocs.io/
+[browser_steps.py]: https://github.com/niccokunzmann/open-web-calendar/blob/main/open_web_calendar/features/steps/browser_steps.py

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -86,4 +86,4 @@ See [Browser Testing](index.md#browser-testing) for where screenshots land
 and how to jump from a failed step back to its source line.
 
 [Behave]: https://behave.readthedocs.io/
-[browser_steps.py]: https://github.com/niccokunzmann/open-web-calendar/blob/main/open_web_calendar/features/steps/browser_steps.py
+[browser_steps.py]: https://github.com/niccokunzmann/open-web-calendar/blob/HEAD/open_web_calendar/features/steps/browser_steps.py

--- a/docs/dev/translate.md
+++ b/docs/dev/translate.md
@@ -10,13 +10,28 @@ description: "Translate the Open Web Calender"
 # Translate
 
 You can help us by [translating the project]({{link.weblate}}) to your language.
-If your language is not listed, please request to add it!
 
 - [Translate on Weblate]({{link.weblate}})
 
 Here, you can see the current translation status:
 
 [![Translation status](https://hosted.weblate.org/widgets/open-web-calendar/-/multi-auto.svg)]({{link.weblate}})
+
+## Request a new language
+
+Adding a new language to the project is restricted to the maintainers
+on Weblate. To get yours added:
+
+1. Open the [Weblate project]({{link.weblate}}), pick any component, and
+   use Weblate's button to suggest or start a new translation in your
+   language. The request reaches the maintainers.
+2. If you do not see the option, open an issue on the
+   [tracker]({{link.issues}}) and mention the language you want.
+
+Once a maintainer adds the language, please translate the `language` and
+`language-en` strings first. They control how the language appears in the
+calendar's language dropdown (see [Calendar language strings](#calendar-language-strings)
+below for details).
 
 ## Translator Guide
 
@@ -34,10 +49,35 @@ After 48 hours they are usually life at the [hosted instance]({{link.web}}).
 Generally, feel free to translate the title and translate the sense of the content more than the literal words.
 I am not a native speaker, so my English is a bit clunky and your translation could be better!
 
-**Note:**
+## Calendar language strings
 
-- If you add a **new language**, you should also translate the calendar to it, especially the `language` and `language-en` strings so people can choose the language for the calendar from the drop down menu.
-- If you want your language to be featured at the top of the front page so people can click on it, you need at least 50% of the About Page and Configuration Page page.
+Two strings in the calendar component control how a language appears in the
+language dropdown:
+
+- `language`: the native name, for example `Deutsch` or `Español`.
+- `language-en`: the English name, for example `German` or `Spanish`,
+  used as a fallback when `language` is not set.
+
+If neither is set, the language does not appear in the dropdown at all.
+Translate both early on so the dropdown shows the native name with the
+English fallback in place.
+
+## Get featured on the front page
+
+For your language to appear in the language list on the front page, you need
+at least **50%** of the strings translated across the **Configuration Page**
+(`index`) and the **Common Translations** (`common`).
+
+## Reporting issues
+
+If you find a typo in the source English, open an issue on the
+[tracker]({{link.issues}}).
+For Weblate itself (component errors, file format issues, missing strings),
+use Weblate's report mechanism inside the component view.
+
+If you are adding a new documentation component, see the
+[maintainer notes](maintain.md#translate-documentation-files) for the
+Weblate setup steps.
 
 Have **fun** translating and thank you so much! If you have any questions, get in contact with me, @niccokunzmann.
 

--- a/docs/dev/translate.md
+++ b/docs/dev/translate.md
@@ -36,7 +36,7 @@ below for details).
 ## Translator Guide
 
 Translations are contributed by volunteers and [logged](../../changelog).
-After 48 hours they are usually life at the [hosted instance]({{link.web}}).
+After 48 hours they are usually live at the [hosted instance]({{link.web}}).
 
 1. The most important file is probably the **calendar file**.
 2. The **About Page** and **Common Translations** is also very important as users see it when they click the `?` at the bottom right.

--- a/docs/dev/unit-tests.md
+++ b/docs/dev/unit-tests.md
@@ -1,0 +1,73 @@
+---
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+comments: true
+description: "Write and run unit tests for the Open Web Calendar."
+---
+
+# Unit Tests
+
+The unit tests live in `open_web_calendar/test/` and run with `pytest`
+through `tox`. They cover the pieces below the HTTP layer: parsing,
+merging, the configuration object, encryption, and so on.
+
+If you have not run the tests before, the
+[running tests section](index.md#running-tests) in the setup guide
+covers `tox` and how to target one Python version.
+
+## Run one test
+
+```sh
+tox -e py -- open_web_calendar/test/test_specification.py
+```
+
+Pass any `pytest` option after the `--`. To run a single test:
+
+```sh
+tox -e py -- open_web_calendar/test/test_specification.py::test_specification_equals_default_specification_by_default
+```
+
+## Fixtures you will use
+
+The shared fixtures are defined in
+[`open_web_calendar/test/conftest.py`][conftest]. The ones you will reach
+for most often:
+
+- `client`: the Flask test client.
+- `cache_url(url, content)`: register a fake HTTP response so your test
+  does not need the network. All outbound HTTP is mocked by default, so
+  any URL the code fetches needs a `cache_url` entry first.
+- `calendar_urls`: a mapping from each `.ics` fixture in
+  `open_web_calendar/features/calendars/` to a cached URL. Look up a
+  fixture by its file stem.
+- `calendar_content`: the same mapping, but returning the raw `.ics`
+  text instead of a URL.
+- `merged(urls, specification)`: fetches `/calendar.ics` with the given
+  fixtures and spec parameters and returns the parsed `icalendar.Calendar`.
+- `production`: flips off debug mode for the duration of the test.
+
+## Add a regression test for a bug
+
+Name the file after the issue: `test_issue_<number>_<short_slug>.py`.
+Most regression tests in `open_web_calendar/test/` follow this pattern.
+Topic-named tests (`test_clean.py`, `test_config.py`, etc.) also exist
+for behavior that is not tied to one bug.
+
+A small regression test looks like this:
+
+```python
+def test_issue_NNN_specific_behavior(merged):
+    cal = merged(
+        urls=["one-event"],
+        specification={"timezone": "UTC"},
+    )
+    events = list(cal.walk("VEVENT"))
+    assert len(events) == 1
+```
+
+For features that are easier to verify in a real browser
+(rendering, clicks, layout), write a [browser test](testing.md) instead.
+
+[conftest]: https://github.com/niccokunzmann/open-web-calendar/blob/main/open_web_calendar/test/conftest.py

--- a/docs/dev/unit-tests.md
+++ b/docs/dev/unit-tests.md
@@ -70,4 +70,4 @@ def test_issue_NNN_specific_behavior(merged):
 For features that are easier to verify in a real browser
 (rendering, clicks, layout), write a [browser test](testing.md) instead.
 
-[conftest]: https://github.com/niccokunzmann/open-web-calendar/blob/main/open_web_calendar/test/conftest.py
+[conftest]: https://github.com/niccokunzmann/open-web-calendar/blob/HEAD/open_web_calendar/test/conftest.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -372,6 +372,8 @@ nav:
   - Development:
     - dev/translate.md
     - dev/index.md
+    - dev/testing.md
+    - dev/unit-tests.md
     - dev/api.md
     - dev/javascript.md
     - dev/maintain.md


### PR DESCRIPTION
Fixes #1115. Fixes #987. Fixes #834.

The Debug Mode section in `dev/index.md` was just an empty code fence with no command. It now shows `tox -e dev` and what the env vars do. The screenshot bit and the file:line clickable note moved up so they sit with the rest of the browser testing content, where they actually belong (per #987).

There was no guide for the Behave suite at all, so anyone new had to read `environment.py` and `browser_steps.py` to figure out the conventions. Added `dev/testing.md` covering where things live, how to run one feature, how to add a `.ics` fixture, and where the step catalogue is. Added `dev/unit-tests.md` for the pytest side too. The conftest fixtures (`client`, `cache_url`, `merged`) are not at all obvious from the file names.

`dev/translate.md` was missing the answers a translator actually needs. Added sections on how to add a new language on Weblate, what the `language` and `language-en` strings do, where to get featured on the front page, and where to report typos vs Weblate engine issues.

The links in `docs/contributing.md` were broken in GitHub's blob view. The `{{link.*}}` template vars rendered as literal text and the `../dev/` relatives 404'd. Swapped them all for absolute URLs so the file works in both renderers. The root `CONTRIBUTING.md` redirect you suggested on #834 is already there, so left as is.

Also rounded out the contribution workflow with the governance files this repo was missing. Added `CODE_OF_CONDUCT.md` pointing to the PCE one, a `CODEOWNERS`, a PR template, and bug, feature, and config issue templates. Both `dev/index.md` and `contributing.md` now link to the PCE AI policy so contributors who use AI know what is expected.

One thing to flag for anyone building the docs locally on Windows. `translations` is a git symlink that Windows checks out as a plain text file, so the build dies with `FileNotFoundError: ...\translations\de`. Fix locally with `mklink /D translations open_web_calendar\translations`, do not commit it. On Linux CI it just works. The build also rewrites `.po` files when source `.md` strings change. Those are translation templates, not part of this PR, the regular "Update translation files" flow handles them.