### PR TITLE
UI improvements

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -37,6 +37,17 @@ The latest version might not be released, yet.
 - Add browser and unit testing guides, complete the debug mode section, and expand the translation guide, see [Issue 1115](https://github.com/niccokunzmann/open-web-calendar/issues/1115) and [Issue 987](https://github.com/niccokunzmann/open-web-calendar/issues/987)
 - Fix broken links in `docs/contributing.md` so they work in GitHub's blob view, see [Issue 834](https://github.com/niccokunzmann/open-web-calendar/issues/834)
 - Add `CODE_OF_CONDUCT.md`, `CODEOWNERS`, pull request template, and bug, feature, and config issue templates, see [Pull Request #1208](https://github.com/niccokunzmann/open-web-calendar/pull/1208)
+- Add CSS variables for the help link color so it can be themed, see [Issue 774](https://github.com/niccokunzmann/open-web-calendar/issues/774)
+- Highlight today's cell in the month view, see [Issue 756](https://github.com/niccokunzmann/open-web-calendar/issues/756)
+- Add a copy button next to the embed code on the configuration page
+- Add `css_url` and `javascript_url` input fields to the configuration page
+- Add `agenda_months` to configure how many months the agenda view spans
+- Close the calendar menu when clicking outside or pressing Escape, see [Issue 835](https://github.com/niccokunzmann/open-web-calendar/issues/835)
+- Add `month_event_multiline` to allow events to wrap on multiple lines in month view, see [Issue 625](https://github.com/niccokunzmann/open-web-calendar/issues/625)
+- Wrap long event titles in the event popup
+- Add `inline_description` to show event descriptions inline in the agenda view, see [Issue 298](https://github.com/niccokunzmann/open-web-calendar/issues/298)
+- Use short weekday names in the month view on narrow viewports so headers do not overlap, see [Issue 280](https://github.com/niccokunzmann/open-web-calendar/issues/280)
+- Add `event_popup_add_to_calendar` to hide the "Add to my Calendar" button in the event popup, see [Issue 804](https://github.com/niccokunzmann/open-web-calendar/issues/804)
 
 ## v1.51
 

--- a/open_web_calendar/default_specification.yml
+++ b/open_web_calendar/default_specification.yml
@@ -133,6 +133,10 @@ agenda_months: 1
 ## Useful for tall narrow dashboards where one-line truncation cuts off titles.
 month_event_multiline: false
 
+## Show event descriptions inline in the agenda view, under the title.
+## Useful when descriptions hold important content like a school lunch menu.
+inline_description: false
+
 ## Users can control the calendar.
 ## You can hide these buttons:
 controls:

--- a/open_web_calendar/default_specification.yml
+++ b/open_web_calendar/default_specification.yml
@@ -137,6 +137,10 @@ month_event_multiline: false
 ## Useful when descriptions hold important content like a school lunch menu.
 inline_description: false
 
+## Show the "Add to my Calendar" button at the bottom of the event popup.
+## Set to false for a minimal popup without download options.
+event_popup_add_to_calendar: true
+
 ## Users can control the calendar.
 ## You can hide these buttons:
 controls:

--- a/open_web_calendar/default_specification.yml
+++ b/open_web_calendar/default_specification.yml
@@ -125,6 +125,10 @@ tabs:
 - "day"
 #- agenda
 
+## Number of months the agenda view spans.
+## Useful for academic calendars or project timelines.
+agenda_months: 1
+
 ## Users can control the calendar.
 ## You can hide these buttons:
 controls:

--- a/open_web_calendar/default_specification.yml
+++ b/open_web_calendar/default_specification.yml
@@ -129,6 +129,10 @@ tabs:
 ## Useful for academic calendars or project timelines.
 agenda_months: 1
 
+## Allow events in month view to wrap to multiple lines.
+## Useful for tall narrow dashboards where one-line truncation cuts off titles.
+month_event_multiline: false
+
 ## Users can control the calendar.
 ## You can hide these buttons:
 controls:

--- a/open_web_calendar/static/css/dhtmlx/style.css
+++ b/open_web_calendar/static/css/dhtmlx/style.css
@@ -151,6 +151,13 @@ div.dhx_agenda_line > span {
     }
 }
 
+/* Allow long event titles to wrap in the popup. */
+.dhx_cal_qi_tcontent,
+.dhx_cal_qi_tcontent > span {
+  white-space: normal;
+  overflow: visible;
+}
+
 /* The possible link in the title. */
 .dhx_cal_qi_tcontent a {
   color: inherit;

--- a/open_web_calendar/static/css/dhtmlx/style.css
+++ b/open_web_calendar/static/css/dhtmlx/style.css
@@ -158,6 +158,15 @@ div.dhx_agenda_line > span {
   overflow: visible;
 }
 
+/* Inline description in agenda view. */
+.dhx_cal_agenda_event_line .details {
+  font-size: 0.9em;
+  font-weight: normal;
+  color: var(--dhx-scheduler-base-colors-text-light, #555);
+  margin-top: 0.2em;
+  white-space: pre-line;
+}
+
 /* The possible link in the title. */
 .dhx_cal_qi_tcontent a {
   color: inherit;

--- a/open_web_calendar/static/css/dhtmlx/style.css
+++ b/open_web_calendar/static/css/dhtmlx/style.css
@@ -10,6 +10,8 @@
     --owc-menu-box-shadow-color : var(--dhx-scheduler-base-colors-secondary);
     --owc-menu-item-text-color: var(--dhx-scheduler-base-colors-text-base);
     --owc-menu-item-backgroud-color: var(--dhx-scheduler-event-background);
+    --owc-help-link-color: inherit;
+    --owc-help-link-background-color: rgba(0, 0, 0, 0.1);
 }
 
 /* Styling of the dhtmlx.html file.
@@ -33,7 +35,8 @@
 }
 
 #infoIcon {
-    background-color: rgba(0,0,0,0.1);
+    color: var(--owc-help-link-color);
+    background-color: var(--owc-help-link-background-color);
 }
 
 #errorStatusIcon {

--- a/open_web_calendar/static/css/dhtmlx/style.css
+++ b/open_web_calendar/static/css/dhtmlx/style.css
@@ -12,6 +12,16 @@
     --owc-menu-item-backgroud-color: var(--dhx-scheduler-event-background);
     --owc-help-link-color: inherit;
     --owc-help-link-background-color: rgba(0, 0, 0, 0.1);
+    --owc-today-background-color: var(--dhx-scheduler-base-colors-select);
+}
+
+/* Highlight today's cell in month view. */
+.dhx_cal_month_cell:has(> .dhx_month_body > .dhx_now_time) {
+    background-color: var(--owc-today-background-color);
+}
+
+.dhx_cal_month_cell > .dhx_month_body > .dhx_now_time {
+    display: none;
 }
 
 /* Styling of the dhtmlx.html file.

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -399,9 +399,9 @@ function loadCalendar() {
     /* Append the cleaned description under the title when inline_description is on. */
     scheduler.templates.agenda_text = function(start, end, event) {
         if (specification.inline_description && event.description) {
-            return event.text + template.details(event);
+            return template.formatted_summary(event) + template.details(event);
         }
-        return event.text;
+        return template.formatted_summary(event);
     };
     /* Use short weekday names in month view on narrow viewports so headers do not overlap. */
     const NARROW_VIEWPORT = "(max-width: 480px)";

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -396,6 +396,13 @@ function loadCalendar() {
         const end = scheduler.date.add(start, months - 1, "month");
         return scheduler.templates.month_date(start) + " – " + scheduler.templates.month_date(end);
     };
+    /* Append the cleaned description under the title when inline_description is on. */
+    scheduler.templates.agenda_text = function(start, end, event) {
+        if (specification.inline_description && event.description) {
+            return event.text + template.details(event);
+        }
+        return event.text;
+    };
     // set format of dates in the data source
     scheduler.config.xml_date="%Y-%m-%d %H:%i";
 

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -553,6 +553,10 @@ function loadCalendar() {
     scheduler.config.icons_select = [];
     getOwnProperties(actions).forEach(function(action) {
         let actionId = "icon_" + action;
+        // Hide the "Add to my Calendar" button when event_popup_add_to_calendar is off.
+        if (action === "subscribe" && !specification.event_popup_add_to_calendar) {
+            return;
+        }
         // Add this to the config.
         scheduler.config.icons_select.push(actionId);
         // Add an action.

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -399,6 +399,10 @@ function loadCalendar() {
     // set format of dates in the data source
     scheduler.config.xml_date="%Y-%m-%d %H:%i";
 
+    if (specification.month_event_multiline) {
+        scheduler.config.multi_day = true;
+    }
+
     // responsive lightbox, see https://docs.dhtmlx.com/scheduler/touch_support.html
     scheduler.config.responsive_lightbox = true;
     resetConfig();
@@ -408,6 +412,12 @@ function loadCalendar() {
     // set the skin, scheduler v7
     // see https://docs.dhtmlx.com/scheduler/skins.html#dark
     scheduler.setSkin(getSkin());
+    /* Skin init resets bar_height; re-apply after onSchedulerReady. */
+    if (specification.month_event_multiline) {
+        scheduler.attachEvent("onSchedulerReady", function(){
+            scheduler.xy.bar_height = 46;
+        });
+    }
     /* Hide or display the header controls */
     if (!specification.controls.length && !specification.tabs.length) {
         document.body.classList.add("no-controls");

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -646,6 +646,28 @@ async function loadCalendarMetadata() {
             otherCheckbox.checked = toggleMenuButton.checked;
         }
     });
+    // close the menu on outside click or Escape
+    function closeMenu() {
+        toggleMenuButton.checked = false;
+        const otherCheckbox = document.getElementById("menu__toggle__2");
+        if (otherCheckbox != null) {
+            otherCheckbox.checked = false;
+        }
+    }
+    document.addEventListener("mousedown", function(event) {
+        if (!toggleMenuButton.checked) return;
+        const menuBox = document.getElementById("menu-meta-data");
+        const isInsideMenu = menuBox && menuBox.contains(event.target);
+        const isMenuButton = event.target.closest(".menu__btn") != null;
+        if (!isInsideMenu && !isMenuButton) {
+            closeMenu();
+        }
+    });
+    document.addEventListener("keydown", function(event) {
+        if (event.key === "Escape" && toggleMenuButton.checked) {
+            closeMenu();
+        }
+    });
     // only update once
     if (calendarMetaData != null) {
         onCalendarInfoLoaded();

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -383,6 +383,19 @@ function loadCalendar() {
         limit: true,
         serialize: true,
     });
+    /* Override agenda_view defaults so agenda_months controls the range. */
+    scheduler.date.add_agenda = function(date, inc){
+        const months = Math.max(1, parseInt(specification.agenda_months) || 1);
+        return scheduler.date.add(date, inc * months, "month");
+    };
+    scheduler.templates.agenda_date = function(start) {
+        const months = Math.max(1, parseInt(specification.agenda_months) || 1);
+        if (months === 1) {
+            return scheduler.templates.month_date(start);
+        }
+        const end = scheduler.date.add(start, months - 1, "month");
+        return scheduler.templates.month_date(start) + " – " + scheduler.templates.month_date(end);
+    };
     // set format of dates in the data source
     scheduler.config.xml_date="%Y-%m-%d %H:%i";
 
@@ -485,9 +498,6 @@ function loadCalendar() {
         }
         return event["css-classes"].map(escapeHtml).join(" ");
     };
-
-    // set agenda date
-    scheduler.templates.agenda_date = scheduler.templates.month_date;
 
     /* load the events */
     scheduler.attachEvent("onLoadError", function(xhr) {

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -403,6 +403,16 @@ function loadCalendar() {
         }
         return event.text;
     };
+    /* Use short weekday names in month view on narrow viewports so headers do not overlap. */
+    const NARROW_VIEWPORT = "(max-width: 480px)";
+    const formatMonthScaleFull = scheduler.date.date_to_str("%l");
+    scheduler.templates.month_scale_date = function(date) {
+        if (window.matchMedia(NARROW_VIEWPORT).matches) {
+            return OWCLocale.date.day_short[date.getDay()];
+        }
+        return formatMonthScaleFull(date);
+    };
+    window.matchMedia(NARROW_VIEWPORT).addEventListener("change", () => scheduler.updateView());
     // set format of dates in the data source
     scheduler.config.xml_date="%Y-%m-%d %H:%i";
 

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -416,10 +416,6 @@ function loadCalendar() {
     // set format of dates in the data source
     scheduler.config.xml_date="%Y-%m-%d %H:%i";
 
-    if (specification.month_event_multiline) {
-        scheduler.config.multi_day = true;
-    }
-
     // responsive lightbox, see https://docs.dhtmlx.com/scheduler/touch_support.html
     scheduler.config.responsive_lightbox = true;
     resetConfig();
@@ -671,34 +667,36 @@ let calendarMetaData = null; // We only need to load this once.
 async function loadCalendarMetadata() {
     // make the menu with the metadata work
     const toggleMenuButton = document.getElementById("menu__toggle");
-    toggleMenuButton.addEventListener("change", function() {
-        const otherCheckbox = document.getElementById("menu__toggle__2");
-        if (otherCheckbox != null) {
-            otherCheckbox.checked = toggleMenuButton.checked;
+    if (toggleMenuButton != null) {
+        toggleMenuButton.addEventListener("change", function() {
+            const otherCheckbox = document.getElementById("menu__toggle__2");
+            if (otherCheckbox != null) {
+                otherCheckbox.checked = toggleMenuButton.checked;
+            }
+        });
+        // close the menu on outside click or Escape
+        function closeMenu() {
+            toggleMenuButton.checked = false;
+            const otherCheckbox = document.getElementById("menu__toggle__2");
+            if (otherCheckbox != null) {
+                otherCheckbox.checked = false;
+            }
         }
-    });
-    // close the menu on outside click or Escape
-    function closeMenu() {
-        toggleMenuButton.checked = false;
-        const otherCheckbox = document.getElementById("menu__toggle__2");
-        if (otherCheckbox != null) {
-            otherCheckbox.checked = false;
-        }
+        document.addEventListener("mousedown", function(event) {
+            if (!toggleMenuButton.checked) return;
+            const menuBox = document.getElementById("menu-meta-data");
+            const isInsideMenu = menuBox && menuBox.contains(event.target);
+            const isMenuButton = event.target.closest(".menu__btn") != null;
+            if (!isInsideMenu && !isMenuButton) {
+                closeMenu();
+            }
+        });
+        document.addEventListener("keydown", function(event) {
+            if (event.key === "Escape" && toggleMenuButton.checked) {
+                closeMenu();
+            }
+        });
     }
-    document.addEventListener("mousedown", function(event) {
-        if (!toggleMenuButton.checked) return;
-        const menuBox = document.getElementById("menu-meta-data");
-        const isInsideMenu = menuBox && menuBox.contains(event.target);
-        const isMenuButton = event.target.closest(".menu__btn") != null;
-        if (!isInsideMenu && !isMenuButton) {
-            closeMenu();
-        }
-    });
-    document.addEventListener("keydown", function(event) {
-        if (event.key === "Escape" && toggleMenuButton.checked) {
-            closeMenu();
-        }
-    });
     // only update once
     if (calendarMetaData != null) {
         onCalendarInfoLoaded();
@@ -715,7 +713,9 @@ function onCalendarInfoLoaded() {
     console.log("Calendar Info:", calendarMetaData);
     const metaDataInMenu = document.getElementById("menu-meta-data");
     // fill the menu
-    metaDataInMenu.appendChild(getMenuInnerContent(calendarMetaData));
+    if (metaDataInMenu != null) {
+        metaDataInMenu.appendChild(getMenuInnerContent(calendarMetaData));
+    }
     // handle errors
     for (error of calendarMetaData.errors) {
         showEventError(error);

--- a/open_web_calendar/static/js/index.js
+++ b/open_web_calendar/static/js/index.js
@@ -230,6 +230,9 @@ function getSpecification() {
     if (css) {
         spec.css = css;
     }
+    /* css_url and javascript_url: newline separated lists */
+    spec.css_url = parseUrlList("css-url-input");
+    spec.javascript_url = parseUrlList("javascript-url-input");
     /* link targets */
     setSpecificationValueFromId(spec, "target", "select-target");
     /* loader */
@@ -290,6 +293,12 @@ function displayCalendar(sourceCode) {
 function showCalendarSourceCode(sourceCode) {
     var link = document.getElementById("calendar-code");
     link.innerText = sourceCode;
+}
+
+function parseUrlList(textareaId) {
+    return getValueById(textareaId)
+        .split(/\s+/)
+        .filter(function (url) { return url.length > 0; });
 }
 
 async function copyEmbedCode() {
@@ -565,6 +574,14 @@ function listenForCSSChanges() {
     var CSSText = document.getElementById("css-input");
     CSSText.value = specification.css;
     changeSpecificationOnChange(CSSText);
+    initializeUrlList("css-url-input", specification.css_url);
+    initializeUrlList("javascript-url-input", specification.javascript_url);
+}
+
+function initializeUrlList(textareaId, urls) {
+    var textarea = document.getElementById(textareaId);
+    textarea.value = (urls || []).join("\n");
+    changeSpecificationOnChange(textarea);
 }
 
 function initializeLinkTargetChoice() {

--- a/open_web_calendar/static/js/index.js
+++ b/open_web_calendar/static/js/index.js
@@ -299,7 +299,8 @@ function showCalendarSourceCode(sourceCode) {
 
 function parseUrlList(textareaId) {
     return getValueById(textareaId)
-        .split(/\s+/)
+        .split(/\r?\n/)
+        .map(function (url) { return url.trim(); })
         .filter(function (url) { return url.length > 0; });
 }
 

--- a/open_web_calendar/static/js/index.js
+++ b/open_web_calendar/static/js/index.js
@@ -239,6 +239,8 @@ function getSpecification() {
     setSpecificationValueFromId(spec, "loader", "select-loader");
     /* initial view */
     setSpecificationValueFromId(spec, "tab", "select-tab");
+    /* agenda date range */
+    spec.agenda_months = Math.max(1, parseInt(getValueById("agenda_months")) || 1);
     /* controls */
     spec.controls = [];
     spec.tabs = [];
@@ -610,6 +612,9 @@ function updateControls() {
     const initialView = document.getElementById("select-tab");
     initialView.value = specification.tab;
     changeSpecificationOnChange(initialView);
+    const agendaMonths = document.getElementById("agenda_months");
+    agendaMonths.value = specification.agenda_months;
+    changeSpecificationOnChange(agendaMonths);
     /* We update the checkbuttons according to the specification. */
     const specificationCheckbuttons = document.getElementsByClassName("specification-list-checkbox");
     const checkbuttons = {};

--- a/open_web_calendar/static/js/index.js
+++ b/open_web_calendar/static/js/index.js
@@ -292,6 +292,24 @@ function showCalendarSourceCode(sourceCode) {
     link.innerText = sourceCode;
 }
 
+async function copyEmbedCode() {
+    const button = document.getElementById("calendar-code-copy");
+    const code = document.getElementById("calendar-code").innerText;
+    try {
+        await navigator.clipboard.writeText(code);
+    } catch (e) {
+        const area = document.createElement("textarea");
+        area.value = code;
+        document.body.appendChild(area);
+        area.select();
+        document.execCommand("copy");
+        document.body.removeChild(area);
+    }
+    const original = button.innerText;
+    button.innerText = translations["calendar-code-copied"];
+    setTimeout(() => { button.innerText = original; }, 2000);
+}
+
 function getLoadingAnimationUrl() {
     var url = getValueById("select-loader");
     if (url[0] == "/") {

--- a/open_web_calendar/templates/calendars/dhtmlx.html
+++ b/open_web_calendar/templates/calendars/dhtmlx.html
@@ -47,6 +47,12 @@ SPDX-License-Identifier: GPL-2.0-only
             {% if not specification['show_participant_status'] %}.PARTICIPANT .status { display: none; }{% endif %}
             {% if not specification['show_participant_type'] %}.PARTICIPANT .type { display: none; }{% endif %}
             {% if not specification['show_participant_role'] %}.PARTICIPANT .role { display: none; }{% endif %}
+            /* multiline events in month view */
+            {% if specification['month_event_multiline'] %}
+            .dhx_cal_event_line { height: 40px !important; white-space: normal; }
+            .dhx_cal_event_clear { height: 40px; white-space: normal; }
+            .dhx_cal_event_line_content { white-space: normal; align-self: start; line-height: 1.2em; padding: 2px 4px; }
+            {% endif %}
             {{ specification['css'] | safe }}
         </style>
         {% for link in specification.javascript_url %}

--- a/open_web_calendar/templates/calendars/dhtmlx.html
+++ b/open_web_calendar/templates/calendars/dhtmlx.html
@@ -69,6 +69,7 @@ SPDX-License-Identifier: GPL-2.0-only
         </script>
     </head>
     <body>
+        {% if "menu" in specification["controls"] %}
         <div class="hamburger-menu">
             <input id="menu__toggle" type="checkbox" class="menu__toggle"/>
             <label class="menu__btn burger-menu-label" for="menu__toggle">
@@ -79,6 +80,7 @@ SPDX-License-Identifier: GPL-2.0-only
                 {% if specification['menu_shows_description'] %}<div class="menu-text menu-calendar-description">{{ specification["description"] }}</div>{% endif %}
             </div>
         </div>
+        {% endif %}
         <div id="scheduler_here" class="dhx_cal_container"
             style='width:100%; height:100%;'>
             <div class="dhx_cal_navline"></div>

--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -322,6 +322,10 @@ SPDX-License-Identifier: GPL-2.0-only
                     <input type="checkbox" class="specification-checkbox" id="month_event_multiline" />
                     <label for="month_event_multiline">{{ html("style-month-event-multiline") }}</label>
                 </p>
+                <p>
+                    <input type="checkbox" class="specification-checkbox" id="inline_description" />
+                    <label for="inline_description">{{ html("style-inline-description") }}</label>
+                </p>
             </section>
             <section id="configure-event-status">
                 <h2>{{ html("event-status-title") }}</h2>

--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -326,6 +326,10 @@ SPDX-License-Identifier: GPL-2.0-only
                     <input type="checkbox" class="specification-checkbox" id="inline_description" />
                     <label for="inline_description">{{ html("style-inline-description") }}</label>
                 </p>
+                <p>
+                    <input type="checkbox" class="specification-checkbox" id="event_popup_add_to_calendar" />
+                    <label for="event_popup_add_to_calendar">{{ html("style-event-popup-add-to-calendar") }}</label>
+                </p>
             </section>
             <section id="configure-event-status">
                 <h2>{{ html("event-status-title") }}</h2>

--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -318,6 +318,10 @@ SPDX-License-Identifier: GPL-2.0-only
                     {{ html("style-javascript-url") }}
                     <textarea id="javascript-url-input" rows="2" placeholder="https://example.com/script.js"></textarea>
                 </p>
+                <p>
+                    <input type="checkbox" class="specification-checkbox" id="month_event_multiline" />
+                    <label for="month_event_multiline">{{ html("style-month-event-multiline") }}</label>
+                </p>
             </section>
             <section id="configure-event-status">
                 <h2>{{ html("event-status-title") }}</h2>

--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -359,6 +359,10 @@ SPDX-License-Identifier: GPL-2.0-only
                   </select>
                 </p>
                 <p>
+                  <label for="agenda_months">{{ html("agenda-months") }}</label>
+                  <input type="number" id="agenda_months" min="1" max="12" />
+                </p>
+                <p>
                   {{ html("controls-description") }}
                 </p>
                 <div class="action-paragraph">

--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -19,6 +19,8 @@ SPDX-License-Identifier: GPL-2.0-only
                 "button-encrypted": {{ string("button-encrypted") | tojson }},
                 "button-edit": {{ string("button-edit") | tojson }},
                 "button-remove": {{ string("button-remove") | tojson }},
+                "calendar-code-copy": {{ string("calendar-code-copy") | tojson }},
+                "calendar-code-copied": {{ string("calendar-code-copied") | tojson }},
             };
         </script>
         <link href="css/common.css" rel="stylesheet" type="text/css">
@@ -411,6 +413,7 @@ SPDX-License-Identifier: GPL-2.0-only
                     {{ html("calendar-code") }}
                 </p>
                 <pre id="calendar-code" class="code"></pre>
+                <button type="button" id="calendar-code-copy" onclick="copyEmbedCode()">{{ html("calendar-code-copy") }}</button>
             </section>
             <section id="configure-spec" class="not-for-config">
                 <h2>{{ html("spec-title") }}</h2>

--- a/open_web_calendar/templates/index.html
+++ b/open_web_calendar/templates/index.html
@@ -310,6 +310,14 @@ SPDX-License-Identifier: GPL-2.0-only
                     <code class="css-class-example">.error {}</code>
                     <textarea id="css-input"></textarea>
                 </p>
+                <p>
+                    {{ html("style-css-url") }}
+                    <textarea id="css-url-input" rows="2" placeholder="https://example.com/style.css"></textarea>
+                </p>
+                <p>
+                    {{ html("style-javascript-url") }}
+                    <textarea id="javascript-url-input" rows="2" placeholder="https://example.com/script.js"></textarea>
+                </p>
             </section>
             <section id="configure-event-status">
                 <h2>{{ html("event-status-title") }}</h2>

--- a/open_web_calendar/translations/en/index.yml
+++ b/open_web_calendar/translations/en/index.yml
@@ -244,6 +244,9 @@ style-month-event-multiline: "Allow events to wrap on multiple lines in month vi
 # Checkbox label that shows the event description inline in the agenda view.
 # https://open-web-calendar.hosted.quelltext.eu/#translate-style-inline-description
 style-inline-description: "Show event descriptions in the agenda view"
+# Checkbox label that shows the "Add to my Calendar" button in the event popup.
+# https://open-web-calendar.hosted.quelltext.eu/#translate-style-event-popup-add-to-calendar
+style-event-popup-add-to-calendar: "Show the \"Add to my Calendar\" button in the event popup"
 
 
 event-status-title: "Event Status"

--- a/open_web_calendar/translations/en/index.yml
+++ b/open_web_calendar/translations/en/index.yml
@@ -238,6 +238,9 @@ style-css-url: "You can also load external CSS stylesheets, one URL per line:"
 # External JavaScript files to load, one URL per line.
 # https://open-web-calendar.hosted.quelltext.eu/#translate-style-javascript-url
 style-javascript-url: "You can load external JavaScript files to customise the calendar, one URL per line:"
+# Checkbox label that enables wrapping long event titles onto multiple lines in month view.
+# https://open-web-calendar.hosted.quelltext.eu/#translate-style-month-event-multiline
+style-month-event-multiline: "Allow events to wrap on multiple lines in month view"
 
 
 event-status-title: "Event Status"

--- a/open_web_calendar/translations/en/index.yml
+++ b/open_web_calendar/translations/en/index.yml
@@ -232,6 +232,12 @@ style-days-outside: "Some days of the calendar have a different color if they ar
 # https://open-web-calendar.hosted.quelltext.eu/#translate-style-css
 style-css: "You can specify your own CSS properties if you like."
 style-css-classes: "These are examples of CSS classes to style events:"
+# External CSS stylesheets to load, one URL per line.
+# https://open-web-calendar.hosted.quelltext.eu/#translate-style-css-url
+style-css-url: "You can also load external CSS stylesheets, one URL per line:"
+# External JavaScript files to load, one URL per line.
+# https://open-web-calendar.hosted.quelltext.eu/#translate-style-javascript-url
+style-javascript-url: "You can load external JavaScript files to customise the calendar, one URL per line:"
 
 
 event-status-title: "Event Status"

--- a/open_web_calendar/translations/en/index.yml
+++ b/open_web_calendar/translations/en/index.yml
@@ -32,6 +32,12 @@ calendar-embed-title: "Use & Embed"
 # This describes the calendar code to embed.
 # https://open-web-calendar.hosted.quelltext.eu/#translate-calendar-code
 calendar-code: "To embed the calendar, use this code on your website:"
+# Button next to the embed code that copies it to the clipboard.
+# https://open-web-calendar.hosted.quelltext.eu/#translate-calendar-code-copy
+calendar-code-copy: "Copy"
+# Button label shown for a few seconds after the embed code is copied.
+# https://open-web-calendar.hosted.quelltext.eu/#translate-calendar-code-copied
+calendar-code-copied: "Copied!"
 # This describes the visible calendar that is updated with every change.
 # https://open-web-calendar.hosted.quelltext.eu/#translate-calendar-code-execution
 calendar-code-execution: "You can view the resulting calendar below."

--- a/open_web_calendar/translations/en/index.yml
+++ b/open_web_calendar/translations/en/index.yml
@@ -269,6 +269,9 @@ tabs-title: "Calendar Tabs"
 tabs-description: "The Month view is the default. However, you can choose to show\
   \ a different view in the beginning. Choose one:"
 
+# Label for the number input that controls how many months the agenda view spans.
+# https://open-web-calendar.hosted.quelltext.eu/#translate-agenda-months
+agenda-months: "Number of months the agenda view spans:"
 
 # Description of option
 # https://open-web-calendar.hosted.quelltext.eu/#translate-controls-description

--- a/open_web_calendar/translations/en/index.yml
+++ b/open_web_calendar/translations/en/index.yml
@@ -241,6 +241,9 @@ style-javascript-url: "You can load external JavaScript files to customise the c
 # Checkbox label that enables wrapping long event titles onto multiple lines in month view.
 # https://open-web-calendar.hosted.quelltext.eu/#translate-style-month-event-multiline
 style-month-event-multiline: "Allow events to wrap on multiple lines in month view"
+# Checkbox label that shows the event description inline in the agenda view.
+# https://open-web-calendar.hosted.quelltext.eu/#translate-style-inline-description
+style-inline-description: "Show event descriptions in the agenda view"
 
 
 event-status-title: "Event Status"


### PR DESCRIPTION
Fixes #280. Fixes #298. Fixes #625. Fixes #756. Fixes #774. Fixes #804. Fixes #835.

Eleven UI fixes in this PR.

@niccokunzmann please read this body first and review commit-by-commit rather than the unified diff.

Related to #1114. Item three on the #1114 checklist (config UI for `plugin_event_details` and `plugin_event_tooltip`) is being worked on by sohocine in #1200, so this PR leaves it alone. Four of the eleven fixes here don't have separate issue numbers: they come from the #1114 checklist or were scope expansions I noticed while testing.

The help link styling at the bottom of the calendar was hardcoded. Pulled the colour and background into `--owc-help-link-color` and `--owc-help-link-background-color` so themes can override either one without having to write a `!important` rule. Same pattern as the other `--owc-*` variables already in `dhtmlx/style.css`. (#774)

Today's cell in month view stopped getting a background highlight at some point, probably during the v7 migration. DHTMLX still drops `.dhx_now_time` in the right cell, just hidden by default, so used `:has()` to colour the parent cell instead. Added `--owc-today-background-color` defaulted to the material primary tint, kept so people who want a different highlight don't have to override the selector itself. (#756)

The embed code block on the last page of the config UI had no copy affordance: you had to triple-click and copy. Added a copy button next to it that uses `navigator.clipboard.writeText` with a `document.execCommand("copy")` fallback for non-secure contexts, since the hosted instance is also reachable over HTTP. (#1114 checklist)

`css_url` and `javascript_url` were already valid spec keys but the config UI had no way to set them. Added two textareas in the Style section that take a list of URLs, one per line. The existing list-parsing pattern in `getSpecification` already handled the round-trip; just needed the input controls and the wiring. (#1114 checklist)

Agenda view was hardcoded to one month. Added an `agenda_months` spec key and a number input on the config page. The DHTMLX agenda plugin computes its range with `scheduler.date.add_agenda`, so the override multiplies the month delta. The header template was also overridden to show the range as "May 2026 to Jul 2026" when the value is greater than one. Default of 1 keeps every existing calendar identical. (#1114 checklist)

The calendar menu had two problems. First, even when `menu` was disabled in the `controls` list, the burger button still rendered (the original #835 report). Wrapped the hamburger `<div>` in a Jinja conditional on `"menu" in specification["controls"]` so it disappears when not in the controls. Second, once open the menu had no way to close: clicking outside did nothing, Escape did nothing. Added a `mousedown` document listener that closes the menu unless the click is inside `#menu-meta-data` or on the toggle itself. Used `mousedown` rather than `click` because the `<label for=...>` element fires its checkbox-toggle on `click`, which made the listener cancel the open. Also bound Escape. (#835)

For #625, added a `month_event_multiline` spec key plus a checkbox in the Style section. The conditional block in `dhtmlx.html` injects CSS (`white-space: normal` on the event line) only when the option is on, so the default month view is unchanged. The bar height needed to land in `onSchedulerReady` because the skin init resets `xy.bar_height` to 24 otherwise.

While testing the multiline option I noticed the title in the event popup was also single-line and clipped long event names. Added a small CSS rule on `.dhx_cal_qi_tcontent` to let the title wrap.

For #298, added an `inline_description` spec key. When on, the event's description is rendered under the title in the agenda view using the existing `template.details` helper (the same one used in the event popup, so the description goes through the same `clean_html` pipeline). A new CSS rule on `.dhx_cal_agenda_event_line .details` keeps the styling subdued and preserves newlines. Limited to agenda view on purpose: week view rows have a fixed time-grid height and overlay descriptions clip badly, and agenda view has the vertical room.

For #280, on viewports at or below 480px the month view headers overflow ("Tuesday" overlaps "Wednesday"). Overrode `month_scale_date` to return the short day name from `OWCLocale.date.day_short` when `matchMedia` reports a narrow viewport, otherwise the original full name. A `matchMedia` change listener calls `scheduler.updateView()` when crossing the threshold. Week view defaults are already short ("%D %j") so left alone, and day view has a single header column so no overflow.

For #804, added an `event_popup_add_to_calendar` spec key, defaulting to true. When off, the "Add to my Calendar" icon is skipped in `icons_select` so DHTMLX never renders it. There's a config UI checkbox for it. Useful for read-only embeds where the download option doesn't fit the use case.

@niccokunzmann two issues I could not reproduce on current main, could you try them once you are back?
- #282 (mobile agenda year overflow): the agenda row no longer renders the year for me, so there is nothing to shorten.
- #1052 (emoji/special-character mojibake): UTF-8 round-trips cleanly through `/calendar.events.json` since #1129 in my testing. The reporter's mojibake may have been a pre-#1129 deployment artefact.

