### PR TITLE
Documentation overhaul

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -48,6 +48,17 @@ The latest version might not be released, yet.
 - Add `inline_description` to show event descriptions inline in the agenda view, see [Issue 298](https://github.com/niccokunzmann/open-web-calendar/issues/298)
 - Use short weekday names in the month view on narrow viewports so headers do not overlap, see [Issue 280](https://github.com/niccokunzmann/open-web-calendar/issues/280)
 - Add `event_popup_add_to_calendar` to hide the "Add to my Calendar" button in the event popup, see [Issue 804](https://github.com/niccokunzmann/open-web-calendar/issues/804)
+- Add a Specification Reference page covering every spec key
+- Add a CSS Classes reference page for the auto-generated event classes
+- Add a Specification Inheritance page covering the precedence of query parameters, `specification_url`, `OWC_SPECIFICATION`, and `default_specification.yml`
+- Add a Security Model page covering the threat model and a sub-path hosting checklist
+- Document the recorded API testing pattern for browser tests
+- Add an Integration Tests page covering Flask test client patterns
+- Document the `--owc-*` CSS variables for theming the help link and today's month-view cell
+- Document the `X-ALT-DESC;FMTTYPE=text/html` ICS output
+- Reorganize the documentation landing page around user tasks
+- Replace stale commit links in `docs/dev/api.md` with stable `master` links
+- Fix `tox -e docs-quick` so the docs build runs without a manual workaround
 
 ## v1.51
 

--- a/docs/dev/api.md
+++ b/docs/dev/api.md
@@ -41,6 +41,21 @@ Additional parameters are required for `/calendar.events.json`:
 - `from=YYYY-MM-DD` - the start of the period in which events happen (inclusive)
 - `to=YYYY-MM-DD` - the end of the period in which events happen (exclusive)
 
+### ICS Output Format
+
+The merged feed at `/calendar.ics` follows
+[RFC 5545](https://www.rfc-editor.org/rfc/rfc5545.html). One detail to
+flag:
+
+`DESCRIPTION` properties that contain HTML are split. The plain-text
+version stays in `DESCRIPTION` (per RFC 5545), and the original HTML
+moves to a parallel `X-ALT-DESC;FMTTYPE=text/html` property. Clients that
+understand `X-ALT-DESC` (Outlook, some Apple Calendar versions) render
+the HTML. Older clients fall back to the plain-text description.
+
+The HTML in `X-ALT-DESC` goes through the same `clean_html_*` rules as
+the rest of the calendar, so it is safe to render.
+
 ## Parameters
 
 All configuration parameters are described sufficiently in the [default_specification].
@@ -79,6 +94,9 @@ you have several options:
 You can change the calendar behavior and looks with parameters.
 If the same parameter is specified in different places, the earlier place listed below has the highest precedence.
 These are the places to specify parameters:
+
+For a worked example and a diagram of how the layers combine, see
+[Specification Inheritance](specification-inheritance).
 
 ### Query parameters
 
@@ -138,8 +156,8 @@ If you add a new parameter as a developer:
 
 ## Specification in the Calendar
 
-[app.py][app.py-81] compiles the specification from the given parameters in `get_specification()`.
-In the [template][dhtmlx-23] you can access the specification through the `specification` variable.
+[app.py][app.py-link] compiles the specification from the given parameters in `get_specification()`.
+In the [template][dhtmlx-link] you can access the specification through the `specification` variable.
 The specification is available to JavaScript as the `specification` variable.
 
 See also:
@@ -147,8 +165,8 @@ See also:
 - [JavaScript Customization](../javascript)
 
 
-[app.py-81]: https://github.com/niccokunzmann/open-web-calendar/blob/85a72dab4561e250aec69b5ad7c3de074eefa1e8/app.py#L81
-[dhtmlx-23]: https://github.com/niccokunzmann/open-web-calendar/blob/85a72dab4561e250aec69b5ad7c3de074eefa1e8/templates/calendars/dhtmlx.html#L23
+[app.py-link]: {{link.code}}/open_web_calendar/app.py
+[dhtmlx-link]: {{link.code}}/open_web_calendar/templates/calendars/dhtmlx.html
 
 ## Specification in the Index Page
 
@@ -159,7 +177,7 @@ specification from the inputs.
 Generally, the `specification` variable should be used.
 
 [default_specification]: {{link.code}}/open_web_calendar/default_specification.yml
-[getSpecification()]: https://github.com/niccokunzmann/open-web-calendar/blob/85a72dab4561e250aec69b5ad7c3de074eefa1e8/static/js/index.js#L93
+[getSpecification()]: {{link.code}}/open_web_calendar/static/js/index.js
 
 ## Architecture
 

--- a/docs/dev/css-classes.md
+++ b/docs/dev/css-classes.md
@@ -1,0 +1,119 @@
+---
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+comments: true
+description: "Reference for the CSS classes that every event in the Open Web Calendar carries, and examples of how to style them."
+---
+
+# Auto-Generated CSS Classes
+
+Every event on the page carries CSS classes that say where it came from
+and what it is.
+Target them from the `css` spec key or a stylesheet loaded via
+`css_url`, and you can restyle events without forking the project.
+
+The classes are generated in
+[`ConvertToEvents.get_event_classes()`]({{link.code}}/open_web_calendar/convert/events.py).
+
+## The Classes
+
+Every event has the `event` class plus a `CALENDAR-INDEX-{n}` class.
+The other classes appear only when the corresponding `VEVENT` property is
+set in the source `.ics` file.
+
+| Class                       | Source                              | Example values                         |
+| --------------------------- | ----------------------------------- | -------------------------------------- |
+| `event`                     | always present                      | (none)                                 |
+| `CALENDAR-INDEX-{n}`        | the position of the source URL      | `CALENDAR-INDEX-0`, `CALENDAR-INDEX-1` |
+| `UID-{uid}`                 | the event's `UID` property          | `UID-abc123@example.com`               |
+| `TRANSP-{value}`            | the `TRANSP` property               | `TRANSP-OPAQUE`, `TRANSP-TRANSPARENT`  |
+| `STATUS-{value}`            | the `STATUS` property               | `STATUS-CONFIRMED`, `STATUS-TENTATIVE`, `STATUS-CANCELLED` |
+| `CLASS-{value}`             | the `CLASS` property                | `CLASS-PUBLIC`, `CLASS-PRIVATE`, `CLASS-CONFIDENTIAL` |
+| `PRIORITY-{0-9}`            | the `PRIORITY` property             | `PRIORITY-1`, `PRIORITY-9`             |
+| `CATEGORY-{category}`       | one class per `CATEGORIES` entry    | `CATEGORY-work`, `CATEGORY-personal`   |
+
+!!! note
+
+    If `CLASS` is set to a value other than `PUBLIC`, `CONFIDENTIAL`, or
+    `PRIVATE`, the event keeps its `CLASS-{original}` class and also
+    picks up `CLASS-PRIVATE`. Unknown values are treated as private; the
+    extra class is a defense-in-depth fallback.
+
+## Built-In Styles
+
+Three classes have spec-level toggles in the [default_specification].
+Turning them on ships the styling for you:
+
+- `style-event-status-tentative` adds `font-style: italic` to
+  `STATUS-TENTATIVE`.
+- `style-event-status-confirmed` adds `font-weight: bold` to
+  `STATUS-CONFIRMED`.
+- `style-event-status-cancelled` adds `text-decoration: line-through` to
+  `STATUS-CANCELLED`.
+
+For anything else, target the classes below directly through `css` or
+`css_url`.
+
+## Examples
+
+### Color a Single Calendar
+
+If you have three calendars in `url`, target `CALENDAR-INDEX-0`,
+`CALENDAR-INDEX-1`, and `CALENDAR-INDEX-2`:
+
+```css
+.CALENDAR-INDEX-0 { background-color: #b3d4fc; }
+.CALENDAR-INDEX-1 { background-color: #fce4b3; }
+.CALENDAR-INDEX-2 { background-color: #c3f0c2; }
+```
+
+### Hide Cancelled Events
+
+Combine the spec-level toggle with a stronger rule:
+
+```css
+.STATUS-CANCELLED { display: none; }
+```
+
+### Style by Category
+
+Target the `CATEGORY-{name}` class.
+The category name comes verbatim from the `CATEGORIES` property of the
+event.
+
+```css
+.CATEGORY-meeting { border-left: 4px solid #ff9800; }
+.CATEGORY-deadline { background-color: #ffe0e0; }
+```
+
+### Mark a Specific Event
+
+Use the `UID-{uid}` class to target a single event.
+This is more durable than targeting a position; UIDs do not change when
+the calendar reloads.
+
+```css
+.UID-team-standup\@example\.com { font-weight: bold; }
+```
+
+The `@` and `.` characters need to be escaped with a backslash in CSS
+selectors.
+
+### Combine Classes
+
+The classes stack. You can scope a rule to a particular calendar and a
+particular status:
+
+```css
+.CALENDAR-INDEX-0.STATUS-TENTATIVE { opacity: 0.6; }
+```
+
+See also:
+
+- [`css` and `css_url`](../../host/configure#configuring-the-default-calendar)
+- [Custom Theme Colors](../../host/configure#custom-theme-colors)
+- [API](api)
+
+[default_specification]: {{link.code}}/open_web_calendar/default_specification.yml

--- a/docs/dev/integration-tests.md
+++ b/docs/dev/integration-tests.md
@@ -1,0 +1,111 @@
+---
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+comments: true
+description: "Write and run integration tests for the Open Web Calendar."
+---
+
+# Integration Tests
+
+Integration tests exercise the Flask app through its HTTP routes.
+They sit between the pure-function [unit tests](unit-tests.md) and the
+full [browser tests](testing.md).
+The runner is `pytest`, and they live alongside the unit tests in
+`open_web_calendar/test/`.
+
+The line between a unit test and an integration test is the `client`
+fixture. A test that imports a helper and asserts on its return value
+is a unit test. A test that issues `client.get("/calendar.events.json")`
+and asserts on the response is an integration test.
+
+If you have not run the tests before, the
+[running tests section](index.md#running-tests) in the setup guide
+covers `tox` and how to target one Python version.
+
+## Run one test
+
+```sh
+tox -e py -- open_web_calendar/test/test_headers.py
+```
+
+Pass any `pytest` option after the `--`. To run a single test:
+
+```sh
+tox -e py -- open_web_calendar/test/test_headers.py::test_ics
+```
+
+## A small integration test
+
+```python
+def test_json_result(client):
+    """Check the JSON response headers."""
+    response = client.get("/calendar.events.json")
+    assert response.access_control_allow_origin == "*"
+    assert response.content_type.startswith("application/json")
+```
+
+`client` is the Flask test client. It bypasses the network and calls
+the app's WSGI handler directly, so the test does not need a running
+server.
+
+## Fixtures you will use
+
+The shared fixtures are defined in
+[`open_web_calendar/test/conftest.py`][conftest]. The ones that matter
+for integration tests:
+
+- `client`: the Flask test client.
+- `cache_url(url, content)`: register a fake HTTP response. Every
+  outbound HTTP call goes through this mock; without a `cache_url`
+  entry, the request fails.
+- `calendar_urls`: a mapping from each `.ics` fixture in
+  `open_web_calendar/features/calendars/` to a cached URL. Look up a
+  fixture by its file stem.
+- `calendar_content`: the same mapping, but returning the raw `.ics`
+  text instead of a URL.
+- `merged(urls, specification)`: fetches `/calendar.ics` with the
+  given fixtures and spec parameters and returns the parsed
+  `icalendar.Calendar`. Most ICS-pipeline regression tests use this.
+- `production`: turns off debug mode for the duration of the test.
+  Use it when the behavior under test depends on debug being off, such
+  as the error 500 page.
+
+## When to write an integration test
+
+Reach for one when the bug or feature touches:
+
+- An HTTP route (`/calendar.html`, `/calendar.events.json`, `/calendar.ics`).
+- Response headers (CORS, content type, caching).
+- The full request-to-response pipeline: spec assembly, source
+  fetching, conversion, serialization.
+- Anything where you need to assert on what a client actually receives.
+
+If the bug is in a pure helper function, a [unit test](unit-tests.md)
+is enough. If the bug is in rendering, clicks, or layout, write a
+[browser test](testing.md) instead.
+
+## Mocking external HTTP
+
+Every HTTP request the app makes during a test is mocked. The default
+is "no network." If your test exercises a code path that fetches an ICS
+or talks to CalDAV, register the response first:
+
+```python
+def test_my_route(client, cache_url):
+    cache_url(
+        "https://example.com/calendar.ics",
+        "BEGIN:VCALENDAR\n...END:VCALENDAR\n",
+    )
+    response = client.get(
+        "/calendar.events.json?url=https://example.com/calendar.ics"
+    )
+    assert response.status_code == 200
+```
+
+For a CalDAV or Nextcloud-style multi-request interaction, recordings
+are the right tool. See
+[Recording API responses](testing.md#recording-api-responses).
+
+[conftest]: https://github.com/niccokunzmann/open-web-calendar/blob/HEAD/open_web_calendar/test/conftest.py

--- a/docs/dev/specification-inheritance.md
+++ b/docs/dev/specification-inheritance.md
@@ -1,0 +1,143 @@
+---
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+comments: true
+description: "How the calendar specification is built from defaults, environment variables, and request parameters."
+---
+
+# Specification Inheritance
+
+The specification is a dictionary that controls everything about a calendar.
+The server builds it fresh for each request, layering values from several
+sources. Later sources win over earlier ones.
+
+The specification is also the project's stable contract.
+The same specification should always produce the same kind of calendar.
+DHTMLX scheduler updates and bug fixes can shift the look, but spec keys
+do not get renamed or removed.
+Hundreds of sites embed calendars that depend on this.
+
+## The Layers
+
+There are five layers. Higher up means higher precedence:
+
+```text
+                       ┌──────────────────────────┐
+                       │ 1. Query parameters      │ highest
+                       ├──────────────────────────┤
+                       │ 2. specification_url     │
+                       ├──────────────────────────┤
+                       │ 3. DEFAULT_SPECIFICATION │ (Python)
+                       ├──────────────────────────┤
+                       │ 4. OWC_SPECIFICATION     │ (env var)
+                       ├──────────────────────────┤
+                       │ 5. default_specification.yml │ lowest
+                       └──────────────────────────┘
+```
+
+The merge starts at layer 5 and works up.
+A key set at layer 1 wins, no matter what the lower layers say.
+A key set nowhere falls through to the default in
+[default_specification.yml]({{link.code}}/open_web_calendar/default_specification.yml).
+
+### 5. default_specification.yml
+
+The base layer. Every spec key has a documented default here.
+Operators should not edit this file. Use `OWC_SPECIFICATION` instead.
+
+### 4. OWC_SPECIFICATION
+
+An optional environment variable. Set it to a path or to an inline YAML
+or JSON string to change defaults for every calendar your instance
+serves.
+
+See [OWC_SPECIFICATION in the configuration guide](../../host/configure#owc_specification).
+
+### 3. open_web_calendar.app.DEFAULT_SPECIFICATION
+
+A Python dict on the `open_web_calendar.app` module.
+It is meant for code that runs inside the same Python process: custom
+hosting code, test setup, that kind of thing.
+Most operators never touch it.
+
+### 2. specification_url
+
+A query parameter that points at a YAML or JSON file.
+The body of that file is layered on top of the defaults before query
+parameters apply.
+
+This is how a small embed URL can carry a big configuration.
+Put the long config in a file and link to it with
+`?specification_url=…`.
+
+### 1. Query parameters
+
+The top layer. Every value in the query string becomes a key in the
+specification.
+This is also the only layer a regular embed user can edit, through the
+configuration page.
+
+## A Worked Example
+
+Say `default_specification.yml` ships with `title: "Open Web Calendar"`.
+
+The operator starts the server like this:
+
+```sh
+OWC_SPECIFICATION='{"title": "Acme Calendar"}' gunicorn open_web_calendar:app
+```
+
+Every calendar now starts with `title: "Acme Calendar"`.
+
+A user embeds the calendar with
+`?specification_url=https://acme.example/owc.yml`.
+The file there contains:
+
+```yaml
+title: "Acme Sports Schedule"
+language: "de"
+```
+
+`title` is now `"Acme Sports Schedule"` and `language` is `"de"`.
+
+The user shares a link with `?title=Friday Match` appended.
+Query parameters apply last, so the final specification is:
+
+- `title: "Friday Match"` (from query param)
+- `language: "de"` (from `specification_url`)
+- everything else from defaults
+
+## Trusted vs Untrusted Layers
+
+Three layers are trusted. The operator who deploys the server sets
+them: `default_specification.yml`, `OWC_SPECIFICATION`, and
+`DEFAULT_SPECIFICATION`.
+
+Two layers are untrusted. Anyone who can hand someone a calendar URL can
+set them: `specification_url` and query parameters.
+
+This matters for spec keys that load code, like `javascript` and
+`javascript_url`.
+When `OWC_ENABLE_JS=false`, those keys are silently dropped from the
+untrusted layers and still work from the trusted ones.
+
+See [Security Model](../../host/security-model) for why this split matters,
+and [`get_specification()` in `app.py`]({{link.code}}/open_web_calendar/app.py)
+for the implementation.
+
+## Where Each Layer Lives
+
+| Layer | Trust | Set by | Edited at |
+| ----- | ----- | ------ | --------- |
+| Query parameters | untrusted | the embedder or the viewer | the embed URL |
+| `specification_url` | untrusted | the embedder | a file on the web |
+| `DEFAULT_SPECIFICATION` | trusted | a developer | Python code |
+| `OWC_SPECIFICATION` | trusted | the operator | an env var or file |
+| `default_specification.yml` | trusted | the project | the source tree |
+
+See also:
+
+- [API](api)
+- [Server Configuration](../../host/configure)

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -13,6 +13,12 @@ Bug fixes that affect the user-facing interface usually ship with a regression t
 We use [Behave] with Selenium to drive a real browser against a live Flask app.
 The suite lives in `open_web_calendar/features/`.
 
+Browser tests are the top layer of the test pyramid.
+[Unit tests](unit-tests.md) cover pure functions and
+[integration tests](integration-tests.md) cover HTTP routes through the
+Flask test client. Reach for a browser test when the behavior under test
+is rendering, clicks, or layout.
+
 If you have not run the browser tests before, start with the
 [browser testing section](index.md#browser-testing) in the setup guide.
 It covers `tox -e web`, picking a browser, and changing the window size.
@@ -84,6 +90,81 @@ If none fits, add a function to `browser_steps.py` decorated with `@given`,
 
 See [Browser Testing](index.md#browser-testing) for where screenshots land
 and how to jump from a failed step back to its source line.
+
+## Recording API responses
+
+Some scenarios talk to a real CalDAV server like Nextcloud. The browser
+tests cannot reach one, so the calls are recorded once and replayed on
+each run. The [responses] library does the replay. Recordings live as
+YAML files under `open_web_calendar/test/responses/`.
+
+Recordings freeze the API in time on purpose. A test should not break
+because Nextcloud shipped a new release overnight. The cost: when the
+external API really does change, the recording has to be re-captured
+against the live server.
+
+### Replay a recording in a feature
+
+In a scenario, load a recording before any step that triggers an HTTP
+request:
+
+```gherkin
+Scenario: A user signs up for an event.
+    Given we load the api recording "issue-680-sign-up-for-event"
+      And we add the calendar "issue-679-sign-up-for-event"
+     When we look at 2025-03-17
+      ...
+```
+
+The argument is the recording stem. The `.yml` extension is implied. The
+recording stops at the end of the scenario.
+
+### Record a new interaction
+
+Start the dev server in recording mode:
+
+```sh
+tox -e dev
+```
+
+The dev server records by default. Every outbound HTTP request is captured
+and written to `open_web_calendar/test/responses/dev.yml` once a second.
+
+Drive the interaction you want to capture: open `index.html`, fill the
+calendar URL, click through the configuration page. Stop the server when
+you are done.
+
+Rename `dev.yml` to a meaningful stem, like
+`issue-1234-event-signup.yml`, and keep it under
+`open_web_calendar/test/responses/`. Reference it from your feature with
+`Given we load the api recording "issue-1234-event-signup"`.
+
+### Replay a recording locally
+
+Pass the recording name to the dev module to run the calendar against a
+saved recording instead of the live network:
+
+```sh
+python -m open_web_calendar.test issue-680-sign-up-for-event
+```
+
+The server still listens on <http://localhost:5000>. Every external HTTP
+call is served from the YAML file. Handy for iterating on a scenario
+before turning it into a feature.
+
+### When to record fresh
+
+Re-record when:
+
+- The external API changes shape (a Nextcloud release, say).
+- You add a scenario that exercises an interaction not in any existing
+  recording.
+- A scenario fails with an `OrderedRegistry` mismatch and the new request
+  order is intentional.
+
+Keep recordings small. One scenario per recording is the norm.
+
+[responses]: https://github.com/getsentry/responses
 
 [Behave]: https://behave.readthedocs.io/
 [browser_steps.py]: https://github.com/niccokunzmann/open-web-calendar/blob/HEAD/open_web_calendar/features/steps/browser_steps.py

--- a/docs/dev/unit-tests.md
+++ b/docs/dev/unit-tests.md
@@ -13,6 +13,12 @@ The unit tests live in `open_web_calendar/test/` and run with `pytest`
 through `tox`. They cover the pieces below the HTTP layer: parsing,
 merging, the configuration object, encryption, and so on.
 
+The project has three testing layers. Unit tests sit at the bottom.
+[Integration tests](integration-tests.md) exercise the Flask app through
+its HTTP routes; they live in the same directory and use the same
+runner. [Browser tests](testing.md) drive a real browser through Behave
+and Selenium.
+
 If you have not run the tests before, the
 [running tests section](index.md#running-tests) in the setup guide
 covers `tox` and how to target one Python version.

--- a/docs/host/configure.md
+++ b/docs/host/configure.md
@@ -69,12 +69,38 @@ Please refer to the [default_specification].
 These values are all documented.
 Please use the [OWC_SPECIFICATION] environment variable to change them.
 
+### Custom Theme Colors
+
+A few CSS variables let you change accent colors without writing custom
+selectors. Override any of them through the `css` or `css_url` spec key.
+
+| Variable                            | What it controls                                       |
+| ----------------------------------- | ------------------------------------------------------ |
+| `--owc-help-link-color`             | Text color of the `?` help link.                       |
+| `--owc-help-link-background-color`  | Background color of the `?` help link.                 |
+| `--owc-today-background-color`      | Background color of today's cell in the month view.    |
+
+A soft yellow today cell takes one rule in your `css` spec key:
+
+```css
+:root {
+  --owc-today-background-color: #fff3a8;
+}
+```
+
+The burger menu also uses CSS variables prefixed with `--owc-menu-*`. They
+default to DHTMLX skin colors and are not part of the stable theming
+surface, but you can override them when needed. See
+[`style.css`]({{link.code}}/open_web_calendar/static/css/dhtmlx/style.css)
+for the full list.
+
 [default_specification]: /assets/default_specification.yml
 [privacy-policy]: ../privacy-policy
 
 See also:
 
 - [API](../../dev/api)
+- [Auto-Generated CSS Classes](../../dev/css-classes) for class-level styling
 
 ## Configuring the Server
 
@@ -170,6 +196,11 @@ By default OWC assumes it runs on its own subdomain with no shared cookies or st
 Even with `OWC_ENABLE_JS=false`, hosts on shared domains should also set a strict
 `Content-Security-Policy` header — this env var prevents OWC from injecting attacker
 JS but does not by itself isolate OWC from the parent origin.
+
+See also:
+
+- [Security Model](security-model) for the full threat model and a sub-path
+  hosting checklist.
 
 ### OWC_ENCRYPTION_KEYS
 
@@ -331,7 +362,7 @@ You can use it in front of the Open Web Calendar to configure access and customi
 !!! note "Operating System"
 
     Squid is available for all major platforms.
-    For the commands and paths of this tutorial, we assume you run Squid on Debain/Ubuntu.
+    For the commands and paths of this tutorial, we assume you run Squid on Debian/Ubuntu.
     The commands might work on other systems, but that is not tested.
 
 After you have installed the [Squid] Proxy, add this file into the  `conf.d` directory.

--- a/docs/host/security-model.md
+++ b/docs/host/security-model.md
@@ -1,0 +1,136 @@
+---
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+comments: true
+description: "How the Open Web Calendar defends against malicious input, and what an operator must do to deploy it safely."
+---
+
+# Security Model
+
+The Open Web Calendar has two layers of defense.
+The project ships the first. The operator owns the second.
+Both layers matter.
+
+## Layer One: Input Handling
+
+Everything that arrives at the server is untrusted: calendar URLs, query
+parameters, the body fetched via `specification_url`, and the contents
+of any `.ics` file the calendar downloads.
+The project handles this layer.
+
+Event description HTML runs through `lxml` before it reaches the browser.
+The `clean_html_*` spec keys control the rules, and the defaults are
+strict.
+The error 500 page escapes exception details, so a crashing request
+cannot reflect HTML or JavaScript back through the response.
+
+Recurring events are capped twice: before expansion via
+`OWC_MAX_SOURCE_EVENTS`, and after expansion via
+`OWC_MAX_RESPONSE_EVENTS` and `OWC_MAX_RESPONSE_MB`.
+A small ICS with a malicious `RRULE` cannot inflate into a denial of
+service.
+
+The encryption module uses Fernet with bcrypt for URL secrets.
+
+Security reports go through [private advisories][advisories] so a fix
+can land before the report is public.
+If you find something in this layer, please follow the
+[Security Policy](../../SECURITY).
+
+[advisories]: https://github.com/niccokunzmann/open-web-calendar/security/advisories
+
+## Layer Two: Safe Deployment
+
+This layer is about where you run the calendar.
+
+The Open Web Calendar loads user-supplied JavaScript through the
+`javascript` and `javascript_url` spec keys.
+That is on purpose. Users extend the calendar without forking the
+project.
+It is also the source of the main deployment risk.
+
+In one sentence: an attacker who can hand someone a calendar URL with a
+`javascript` payload can run arbitrary JavaScript in whatever origin
+serves the calendar.
+
+On a dedicated subdomain, this is fine.
+The script runs only in the calendar's own origin, and there is nothing
+interesting there.
+On a shared origin, the script runs alongside whatever else is on that
+origin. It can read cookies, read local storage, and call APIs.
+
+### Safe by Default
+
+The calendar is safe with no extra work when it runs on:
+
+- A dedicated domain such as `calendar.example.com`.
+- A dedicated subdomain with no shared cookies. `SameSite` defaults do
+  not cross subdomains, but it is worth a check on the other services.
+- A separate origin entirely, such as the hosted instance at
+  [open-web-calendar.hosted.quelltext.eu]({{ link.web }}).
+
+[open-web-calendar.hosted.quelltext.eu]: {{ link.web }}
+
+### Shared Origin
+
+Action is needed when the calendar shares an origin with another
+service, in either of these shapes:
+
+- **Same domain, different sub-path.** `example.com/calendar/` alongside
+  `example.com/app/`. Cookies and storage are shared.
+- **Same domain, root path.** Same risk; just no sub-path.
+
+Set [`OWC_ENABLE_JS=false`](../configure#owc_enable_js) on the calendar
+server.
+The configuration guide covers the exact behavior.
+
+Then add a strict `Content-Security-Policy` header through your reverse
+proxy.
+`OWC_ENABLE_JS=false` keeps OWC from injecting attacker JS, but it does
+not isolate the response from the parent origin on its own.
+A minimal CSP that disables inline scripts and limits sources to the
+calendar's own origin:
+
+```text
+Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;
+```
+
+Adjust `style-src` and `img-src` to match the calendars and images you
+need to display.
+
+### Sub-Path Hosting Checklist
+
+When the calendar must live at a sub-path:
+
+1. Set `OWC_ENABLE_JS=false`.
+2. Add a strict `Content-Security-Policy` header.
+3. Set `ALLOWED_HOSTS` to your domain. Requests with a `Host` header
+   that does not match are rejected before any route runs.
+4. Put SSRF protection in front of the calendar. See
+   [SSRF Protection with a Proxy Server](../configure#ssrf-protection-with-a-proxy-server).
+5. Review the [`clean_html_*` defaults](/assets/default_specification.yml).
+   Tighter is safer.
+
+## What the Project Will Not Do
+
+A few choices that are unlikely to change.
+
+JavaScript stays a first-class spec key.
+Killing it project-wide would break legitimate uses.
+`OWC_ENABLE_JS` is the per-instance switch for the operators who need it
+off.
+
+The server does not run untrusted code.
+Every script from a spec key runs in the browser only.
+
+No logging of calendar contents or IP addresses by default.
+See the [Privacy Policy](../privacy-policy) for what the hosted instance
+records.
+
+See also:
+
+- [Security Policy](../../SECURITY)
+- [Server Configuration](../configure)
+- [Privacy Policy](../privacy-policy)

--- a/docs/host/security-model.md
+++ b/docs/host/security-model.md
@@ -66,8 +66,11 @@ origin. It can read cookies, read local storage, and call APIs.
 The calendar is safe with no extra work when it runs on:
 
 - A dedicated domain such as `calendar.example.com`.
-- A dedicated subdomain with no shared cookies. `SameSite` defaults do
-  not cross subdomains, but it is worth a check on the other services.
+- A dedicated subdomain with no shared cookies or storage.
+  Cookies stay isolated only when no other service on the same site
+  sets cookies with `Domain=example.com` or `Domain=.example.com`,
+  since those are sent to every subdomain. `SameSite` does not help
+  here; it gates cross-site requests, not cross-subdomain ones.
 - A separate origin entirely, such as the hosted instance at
   [open-web-calendar.hosted.quelltext.eu]({{ link.web }}).
 

--- a/docs/host/self.md
+++ b/docs/host/self.md
@@ -73,6 +73,14 @@ watch the [GitHub repository]({{link.repo}}).
 After you have set up your own server,
 you can [configure the behavior](../configure).
 
+## Hosting on a Shared Domain
+
+If the calendar runs on the same domain as another service, set
+[`OWC_ENABLE_JS=false`](../configure#owc_enable_js) and add a strict
+`Content-Security-Policy` header through your reverse proxy.
+The full reasoning and a sub-path hosting checklist are in the
+[Security Model](../security-model).
+
 
 [open-web-calendar.hosted.quelltext.eu]: {{link.web}}
 [tor.open-web-calendar.hosted.quelltext.eu]: {{link.tor}}

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,54 @@ Give a calendar your personal touch within minutes!
 - **[Try it out now!]({{link.web}})**
 - [See Examples](templates)
 
+## Getting Started
+
+Pick the path that matches what you have.
+
+### I have an ICS URL
+
+1. Open the [configuration page]({{link.web}}).
+2. Paste the ICS URL into the calendar URL input near the top of the
+   page.
+3. Adjust the title, language, and starting tab.
+4. Copy the embed snippet at the bottom of the page into your website.
+
+The hosted instance at <{{link.web}}> is free to use.
+To run your own, see [Self-Hosting](host/self).
+
+### I have CalDAV
+
+The Open Web Calendar talks to CalDAV servers like Nextcloud.
+The setup is the same as an ICS URL; just point at the CalDAV endpoint
+instead.
+
+For a CalDAV calendar where viewers sign up to events, see the
+[CalDAV Sign Up tutorial](news/2025-03-17-caldav-nextcloud-sign-up).
+
+### I want to customize the appearance
+
+Three ways, in order of effort:
+
+- **Quick changes** in the configuration page: title, colors, hours,
+  controls.
+- **Theme colors** through `--owc-*` CSS variables in your `css` spec
+  key. See [Custom Theme Colors](host/configure#custom-theme-colors).
+- **Full control** by writing CSS that targets the auto-generated
+  event classes. See [CSS Classes](dev/css-classes).
+
+For the full list of spec keys, see the
+[Specification Reference](reference).
+
+### I want to host my own instance
+
+Start with [Self-Hosting](host/self) and
+[Server Configuration](host/configure).
+
+If the calendar will share a domain with another service, read the
+[Security Model](host/security-model) before you go live.
+
+## Features
+
 | Features |  |
 | --- | --- |
 | Instant Event Syncing | <center>✔</center> |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,464 @@
+---
+# SPDX-FileCopyrightText: 2026 Nicco Kunzmann and Open Web Calendar Contributors <https://open-web-calendar.quelltext.eu/>
+#
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+comments: true
+description: "Every spec key in the Open Web Calendar, what it does, what it accepts, and what it defaults to."
+---
+
+# Specification Reference
+
+This page lists every spec key, grouped by purpose.
+Every key has a default in [default_specification.yml].
+Override any of them in a query parameter, a `specification_url` file,
+or the `OWC_SPECIFICATION` env var on the server.
+For the order of precedence, see [Specification Inheritance](dev/specification-inheritance).
+
+[default_specification.yml]: {{link.code}}/open_web_calendar/default_specification.yml
+
+## Content Sources
+
+### `url`
+
+The calendar feed URL or a list of URLs.
+Each URL points to an ICS file or a CalDAV endpoint.
+When more than one URL is given, all events are merged into a single view.
+
+Type: string or list of strings.
+Default: a sample Germany holidays calendar.
+
+```yaml
+url:
+  - https://example.com/team.ics
+  - https://example.com/personal.ics
+```
+
+### `specification_url`
+
+A URL whose body is fetched and layered on top of the defaults.
+The body must be valid YAML or JSON.
+
+Type: string.
+Default: not set.
+
+See [Specification Inheritance](dev/specification-inheritance) for how this
+combines with other layers.
+
+## Display
+
+### `title`
+
+The HTML page title.
+
+Type: string. Default: `"Open Web Calendar"`.
+
+### `favicon`
+
+URL to the favicon. Absolute URLs and absolute paths under the same origin
+are both allowed.
+
+Type: string. Default: `"/static/img/logo/owc.svg"`.
+
+### `description`
+
+A short paragraph shown in the menu. Falls back to the project description
+when empty.
+
+Type: string. Default: empty.
+
+### `date`
+
+The starting date of the calendar view in `YYYY-MM-DD` format. Empty means
+today.
+
+Type: string. Default: empty.
+
+### `tab`
+
+The view selected when the calendar opens.
+
+Type: string. Default: `"month"`. Values: `"month"`, `"week"`, `"day"`,
+`"agenda"`.
+
+### `tabs`
+
+The list of views the user can switch between.
+
+Type: list of strings. Default: `["month", "week", "day"]`.
+
+### `agenda_months`
+
+The number of months the agenda view spans. Useful for academic calendars
+or project timelines.
+
+Type: integer. Default: `1`.
+
+### `month_event_multiline`
+
+When `true`, events in the month view wrap onto multiple lines instead of
+truncating. Useful for tall narrow dashboards.
+
+Type: boolean. Default: `false`.
+
+### `inline_description`
+
+When `true`, event descriptions are rendered under the title in the agenda
+view. Useful when descriptions hold important content, like a school lunch
+menu.
+
+Type: boolean. Default: `false`.
+
+### `start_of_week`
+
+The first day of the week.
+
+Type: string. Default: `"mo"`. Values: `"mo"` (Monday), `"su"` (Sunday),
+`"work"` (Monday to Friday only).
+
+### `starting_hour`
+
+The first hour of the day visible in day and week views.
+
+Type: string. Default: `"0"`.
+
+### `ending_hour`
+
+The last hour of the day visible in day and week views.
+
+Type: string. Default: `"24"`.
+
+### `hour_division`
+
+The vertical resolution of day and week views.
+
+Type: string. Default: `"1"`. Values: `"1"` (one hour), `"2"` (30 minutes),
+`"4"` (15 minutes), `"6"` (10 minutes).
+
+### `hour_format`
+
+The format string for hour labels.
+See the [DHTMLX format reference](https://docs.dhtmlx.com/scheduler/settings_format.html).
+
+Type: string. Default: `"%H:%i"` (24-hour). Other useful values: `"%G:%i"`
+(24-hour without leading zero), `"%g:%i %a"` (12-hour with am/pm).
+
+### `timezone`
+
+The IANA timezone the events are displayed in. Empty means the viewer's
+local timezone.
+
+Type: string. Default: empty.
+
+### `language`
+
+The default calendar language. The list of valid codes is in the
+[translations directory]({{link.code}}/open_web_calendar/translations/).
+
+Type: string. Default: `"en"`.
+
+### `prefer_browser_language`
+
+When `true`, the calendar uses the browser's language when one of the
+supported languages matches. Falls back to the `language` key otherwise.
+
+Type: boolean. Default: `false`.
+
+### `target`
+
+Where links open.
+
+Type: string. Default: `"_top"`. Values: `"_top"` (replace the embedding
+page), `"_blank"` (new tab), `"_self"` (replace the calendar), `"_parent"`
+(the parent frame).
+
+### `compact_layout_width`
+
+The viewport width in pixels at which the calendar switches to a compact
+layout so all controls still fit.
+
+Type: integer. Default: `600`.
+
+### `loader`
+
+The URL of an animated image shown while events are loading.
+
+Type: string. Default: `"/img/loaders/circular-loader.gif"`.
+
+## Skin and Styling
+
+### `skin`
+
+The DHTMLX skin used for the calendar.
+
+Type: string. Default: `"material"`. Values: `"material"`,
+`"contrast-black"`, `"terrace"`, `"contrast-white"`, `"flat"`, `"dark"`.
+
+### `css`
+
+Inline CSS injected into the calendar page.
+
+Type: string. Default: empty.
+
+### `css_url`
+
+A list of URLs to external stylesheets loaded into the calendar page.
+
+Type: list of strings. Default: empty.
+
+For class names you can target, see [CSS Classes](dev/css-classes).
+For theme color variables, see
+[Custom Theme Colors](host/configure#custom-theme-colors).
+
+### `style-event-status-tentative`
+
+When `true`, events with `STATUS:TENTATIVE` are rendered in italic.
+
+Type: boolean. Default: `false`.
+
+### `style-event-status-confirmed`
+
+When `true`, events with `STATUS:CONFIRMED` are rendered in bold, and all
+other events lose their default bold weight.
+
+Type: boolean. Default: `false`.
+
+### `style-event-status-cancelled`
+
+When `true`, events with `STATUS:CANCELLED` are rendered with a
+strikethrough.
+
+Type: boolean. Default: `false`.
+
+## Controls and Menu
+
+### `controls`
+
+The list of header controls the user can see and use.
+
+Type: list of strings. Default: `["next", "previous", "today", "date"]`.
+Values: `"next"`, `"previous"`, `"today"`, `"date"`, `"menu"`.
+
+### `menu_shows_title`
+
+When `true`, the calendar title appears in the burger menu.
+
+Type: boolean. Default: `true`.
+
+### `menu_shows_description`
+
+When `true`, the calendar description appears in the burger menu.
+
+Type: boolean. Default: `true`.
+
+### `menu_shows_calendar_names`
+
+When `true`, the burger menu lists the name of every URL in `url`.
+
+Type: boolean. Default: `true`.
+
+### `menu_shows_calendar_descriptions`
+
+When `true`, the burger menu lists the description of every URL in `url`.
+
+Type: boolean. Default: `false`.
+
+### `menu_shows_calendar_visibility_toggle`
+
+When `true`, each entry in the burger menu has a checkbox to hide that
+calendar from the view.
+
+Type: boolean. Default: `false`.
+
+### `event_popup_add_to_calendar`
+
+When `true`, the event popup shows an "Add to my Calendar" button that
+downloads the event as `.ics`.
+
+Type: boolean. Default: `true`.
+
+## Plugins
+
+### `plugin_event_details`
+
+When `true`, clicking an event opens the popup with the event details.
+
+Type: boolean. Default: `true`.
+
+### `plugin_event_tooltip`
+
+When `true`, hovering an event shows a tooltip with the event summary.
+The tooltip is suppressed on touch devices regardless of this setting.
+
+Type: boolean. Default: `true`.
+
+## Participants
+
+### `show_organizers`
+
+When `true`, the event popup lists the event organizer.
+See [RFC 5545 ORGANIZER](https://www.rfc-editor.org/rfc/rfc5545.html#page-113).
+
+Type: boolean. Default: `false`.
+
+### `show_attendees`
+
+When `true`, the event popup lists the event attendees.
+See [RFC 5545 ATTENDEE](https://www.rfc-editor.org/rfc/rfc5545.html#page-108).
+
+Type: boolean. Default: `false`.
+
+### `show_participant_status`
+
+When `true`, the participant entry includes the participation status
+(`ACCEPTED`, `DECLINED`, `TENTATIVE`, `NEEDS-ACTION`).
+Requires `show_organizers` or `show_attendees`.
+
+Type: boolean. Default: `false`.
+
+### `show_participant_type`
+
+When `true`, the participant entry includes the participant type
+(`INDIVIDUAL`, `GROUP`, `RESOURCE`, `ROOM`).
+Requires `show_organizers` or `show_attendees`.
+
+Type: boolean. Default: `false`.
+
+### `show_participant_role`
+
+When `true`, the participant entry includes the role (`CHAIR`,
+`REQ-PARTICIPANT`, `OPT-PARTICIPANT`, `NON-PARTICIPANT`).
+Requires `show_organizers` or `show_attendees`.
+
+Type: boolean. Default: `false`.
+
+## Maps
+
+### `event_url_location`
+
+The template URL that the event's `LOCATION` text expands into.
+Must contain `{location}` and can contain `{zoom}`.
+
+Type: string. Default: `"https://www.openstreetmap.org/search?query={location}"`.
+
+### `event_url_geo`
+
+The template URL that the event's `GEO` property (latitude and longitude)
+expands into.
+Must contain `{lat}` and `{lon}` and can contain `{zoom}`.
+
+Type: string. Default: `"https://www.openstreetmap.org/#map={zoom}/{lat}/{lon}"`.
+
+See the [icalendar-compatibility map spec](https://icalendar-compatibility.readthedocs.io/en/latest/usage.html#custom-map-spec)
+for the underlying library.
+
+## JavaScript
+
+### `javascript`
+
+Inline JavaScript injected into the calendar page.
+
+Type: string. Default: empty.
+
+!!! warning
+
+    JavaScript from untrusted sources is dropped when the server runs with
+    `OWC_ENABLE_JS=false`. See [Security Model](host/security-model).
+
+### `javascript_url`
+
+A list of URLs to external JavaScript files loaded into the calendar page.
+Absolute URLs are routed through `/js/proxy` to enforce the correct
+content type.
+
+Type: list of strings. Default: empty.
+
+## HTML Cleaning
+
+Event descriptions and inline HTML are cleaned through `lxml` before
+rendering. The strict defaults below ship with the project. Loosening any
+of them can make your instance vulnerable to script injection from
+malicious calendars.
+
+| Key | Default | What it does |
+| --- | --- | --- |
+| `clean_html_page_structure` | `true` | Remove `<head>`, `<body>`, `<html>` tags |
+| `clean_html_meta` | `true` | Remove `<meta>` tags |
+| `clean_html_embedded` | `true` | Remove `<embed>`, `<object>`, `<applet>` |
+| `clean_html_links` | `true` | Remove `<link>` and `@import` references |
+| `clean_html_style` | `true` | Remove `<style>` blocks |
+| `clean_html_processing_instructions` | `true` | Remove `<?...?>` processing instructions |
+| `clean_html_inline_style` | `true` | Remove inline `style="..."` attributes |
+| `clean_html_scripts` | `true` | Remove `<script>` tags |
+| `clean_html_javascript` | `true` | Remove `javascript:` URLs |
+| `clean_html_comments` | `true` | Remove HTML comments |
+| `clean_html_frames` | `true` | Remove `<frame>` and `<iframe>` |
+| `clean_html_forms` | `true` | Remove `<form>` and form controls |
+| `clean_html_annoying_tags` | `true` | Remove `<blink>`, `<marquee>`, etc. |
+| `clean_html_remove_unknown_tags` | `true` | Remove tags lxml does not know |
+| `clean_html_safe_attrs_only` | `true` | Strip every attribute not in `clean_html_safe_attrs` |
+| `clean_html_safe_attrs` | see below | The whitelist used by `clean_html_safe_attrs_only` |
+| `clean_html_remove_tags` | `[body, head, html]` | Tags whose content survives but the tag itself is removed |
+
+Default `clean_html_safe_attrs`: `src`, `color`, `href`, `title`, `class`,
+`name`, `id`.
+
+See the [lxml Cleaner documentation](https://lxml.de/api/lxml.html.clean.Cleaner-class.html)
+for the underlying library.
+
+## Project Identification
+
+### `source_code`
+
+The URL where users can find the project source. Required by the GPL when
+you modify the project.
+
+Type: string. Default: `"https://github.com/niccokunzmann/open-web-calendar/"`.
+
+### `version`
+
+The version string shown next to the source code link. Empty falls back to
+the installed package version.
+
+Type: string. Default: empty.
+
+### `contributing`
+
+The URL of the contribution guide shown in the about page.
+
+Type: string. Default: `"https://open-web-calendar.quelltext.eu/contributing/"`.
+
+### `translate`
+
+The URL of the translation platform shown in the about page.
+
+Type: string. Default: `"https://hosted.weblate.org/engage/open-web-calendar/"`.
+
+### `privacy_policy`
+
+The URL of the privacy policy linked from the about page.
+
+Type: string. Default: `"https://open-web-calendar.quelltext.eu/host/privacy-policy/"`.
+
+## Internal
+
+Set by the project. You will not need to touch these.
+
+### `template`
+
+The Jinja template that renders the calendar page.
+
+Type: string. Default: `"dhtmlx.html"`.
+
+### `timeshift`
+
+Set by the DHTMLX scheduler at render time.
+
+Type: integer. Default: `0`.
+
+See also:
+
+- [API](dev/api)
+- [Specification Inheritance](dev/specification-inheritance)
+- [Server Configuration](host/configure)
+- [CSS Classes](dev/css-classes)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -351,6 +351,7 @@ extra: # language support, see https://squidfunk.github.io/mkdocs-material/setup
 # navigation, see https://www.mkdocs.org/user-guide/configuration/#nav
 nav:
   - index.md
+  - reference.md
   - templates.md
   - Showcase:
     - showcase/index.md
@@ -368,13 +369,17 @@ nav:
     - host/docker.md
     - host/pypi.md
     - host/configure.md
+    - host/security-model.md
     - host/migrate.md
   - Development:
     - dev/translate.md
     - dev/index.md
     - dev/testing.md
     - dev/unit-tests.md
+    - dev/integration-tests.md
     - dev/api.md
+    - dev/specification-inheritance.md
+    - dev/css-classes.md
     - dev/javascript.md
     - dev/maintain.md
     - dev/license.md

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ basepython = python3.11
 deps =
     -r {toxinidir}/requirements/docs.txt
 commands =
-    mkdocs {posargs} -f mkdocs.test.yml 
+    mkdocs {posargs:build} -f mkdocs.test.yml
 
 [testenv:reuse]
 deps = -e .[test-fix]


### PR DESCRIPTION
`Prompt to AI to generate the PR body: "Draft me a PR body for the diff against upstream main"`

#1116

New pages:
- Specification Reference
- Security Model
- Specification Inheritance
- Integration Tests
- Auto-Generated CSS Classes

Existing pages extended:
- `dev/testing.md`: documents the recorded-API testing pattern.
- `host/configure.md`: documents the `--owc-*` theme variables shipped in #1220.
- `host/self.md`: points shared-domain hosters at the security model.
- `docs/index.md`: restructured around user tasks (ICS, CalDAV, customize, self-host).

Fixes:
- `tox -e docs-quick` was broken; passes `-f` correctly now.
- Three stale 2019 commit links in `dev/api.md` replaced with stable paths.
- "Debain" → "Debian" in `host/configure.md`.