### PR TITLE
deps: bump icalendar to 7.1.3 (CVE-2026-55099)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,7 +40,7 @@ flask-allowed-hosts==1.2.0
     # via -r requirements/base.in
 gunicorn==25.3.0
     # via -r requirements/base.in
-icalendar==7.1.0
+icalendar==7.1.3
     # via
     #   -r requirements/base.in
     #   caldav


### PR DESCRIPTION
Updates `icalendar` to 7.1.3 to address CVE-2026-55099 (GHSA-cv84-9p8j-fj68, algorithmic complexity in Equality, HIGH).

Evidence:
- `requirements/base.txt` pinned `icalendar==7.1.0`
- `pip-audit -r requirements/base.txt --no-deps` reported CVE-2026-55099 (fix: 7.1.3) before the update
- updated version: `icalendar==7.1.3`

Validation:
- `pip-audit -r requirements/base.txt --no-deps` no longer reports CVE-2026-55099
- `pytest open_web_calendar/test/` passes: 367 passed, 3 skipped

Note: pip-audit still reports separate advisories for other pinned packages: `cryptography==48.0.1` (PYSEC-2026-3552, PYSEC-2026-3553, PYSEC-2026-3554) and `urllib3==2.4.0` (PYSEC-2026-141, PYSEC-2026-1994, PYSEC-2026-1996, PYSEC-2026-1997, PYSEC-2026-1998, PYSEC-2026-1999). This patch only clears the icalendar finding.

Scope: `requirements/base.txt` only.
