### PR TITLE
Fix agenda only view crash

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@ The latest version might not be released, yet.
 
 ## v1.52 (Unreleased)
 
+- Fix agenda view crash when both `controls` and `tabs` are empty — the agenda view requires the `.dhx_cal_date` element in the navline, which was previously excluded from the header when no controls were selected
 - Migrate the documentation stack from MkDocs to Sphinx with the MyST
   parser, sphinx-intl for translations, and pydata-sphinx-theme, see
   [Issue 1116](https://github.com/niccokunzmann/open-web-calendar/issues/1116)

--- a/open_web_calendar/features/select-tabs-and-control-buttons.feature
+++ b/open_web_calendar/features/select-tabs-and-control-buttons.feature
@@ -47,3 +47,13 @@ Feature: I would like to choose which tabs to display.
       And we set the "controls" parameter to ""
      When we look at 2024-01-18
      Then we can see the text "DAY"
+
+  Scenario: The navline remains visible when controls are empty but tabs are present.
+    Given we add the calendar "one-event"
+      And we set the "controls" parameter to ""
+      And we set the "tabs" parameter to ["day"]
+     When we look at 2024-01-18
+     Then we can see the text "January 2024"
+     Then we cannot see a dhx_cal_prev_button
+     Then we cannot see a dhx_cal_today_button
+     Then we cannot see a dhx_cal_next_button

--- a/open_web_calendar/static/css/dhtmlx/style.css
+++ b/open_web_calendar/static/css/dhtmlx/style.css
@@ -342,14 +342,9 @@ div.dhx_agenda_line > span {
     display: none;
 }
 
-.no-controls .dhx_cal_navline {
-    /* hide the navline if we have no controls */
+.no-controls .dhx_cal_navline .dhx_cal_navline_buttons {
+    /* hide the prev/next/today buttons if we have no controls */
     display: none;
-}
-
-.no-controls {
-    /* hide the navline if we have no controls */
-    --dhx-scheduler-toolbar-height: 0px;
 }
 
 /* START Burger Menu

--- a/open_web_calendar/static/js/calendar.js
+++ b/open_web_calendar/static/js/calendar.js
@@ -266,7 +266,7 @@ function getHeader() {
     // elements that do not occur in the list will always be permitted
     const useHeaderElement = {
       "prev": specification.controls.includes("previous") ,
-      "date": specification.controls.includes("date"),
+      "date": specification.controls.includes("date") || specification.tabs.length > 0,
       "next": specification.controls.includes("next"),
       "day": specification.tabs.includes("day"),
       "week": specification.tabs.includes("week"),


### PR DESCRIPTION
Fixes two related bugs that break the agenda-only view (when both `controls` and `tabs` are configured to show only the agenda tab).

```
Uncaught TypeError: Cannot set properties of null (setting 'innerHTML')
     at dhtmlxscheduler.js:53:427
```