### PR TITLE
Show full year ahead in agenda view by default

### DIFF
--- a/open_web_calendar/default_specification.yml
+++ b/open_web_calendar/default_specification.yml
@@ -127,7 +127,7 @@ tabs:
 
 ## Number of months the agenda view spans.
 ## Useful for academic calendars or project timelines.
-agenda_months: 1
+agenda_months: 12
 
 ## Allow events in month view to wrap to multiple lines.
 ## Useful for tall narrow dashboards where one-line truncation cuts off titles.


### PR DESCRIPTION
Change the default agenda_months from 1 to 12 so the agenda view shows a full year of events by default, instead of just one month.

https://github.com/niccokunzmann/open-web-calendar/issues/615

https://github.com/niccokunzmann/open-web-calendar/issues/1114